### PR TITLE
Fix performance issue when inserting and updating token prices

### DIFF
--- a/src/main/controllers/models/token-price.js
+++ b/src/main/controllers/models/token-price.js
@@ -15,6 +15,8 @@ module.exports = function (app, sqlLiteService) {
     Controller.findBySymbol = _findBySymbol;
     Controller.add = _add;
     Controller.edit = _edit;
+    Controller.bulkEdit = _bulkEdit;
+    Controller.bulkAdd = _bulkAdd;
 
     function _findAll() {
         return new Promise((resolve, reject) => {
@@ -42,6 +44,14 @@ module.exports = function (app, sqlLiteService) {
 
     function _edit(tokenPrice) {
         return sqlLiteService.updateById(TABLE_NAME, tokenPrice);
+    }
+
+    function _bulkEdit(tokenPrices) {
+        return sqlLiteService.bulkUpdateById(TABLE_NAME, tokenPrices);
+    }
+
+    function _bulkAdd(tokenPrices) {
+        return sqlLiteService.bulkAdd(TABLE_NAME, tokenPrices);
     }
 
     return Controller;

--- a/src/main/migrations/20180508093508_init.js
+++ b/src/main/migrations/20180508093508_init.js
@@ -80,7 +80,7 @@ exports.up = function(knex, Promise) {
 		knex.schema.createTable('token_prices', table => {
 			table.increments('id')
 			table.string('name').notNullable()
-			table.string('symbol').notNullable().unique()
+			table.string('symbol').notNullable()
 			table.string('source')
 			table.decimal('priceUSD')
 			table.decimal('priceBTC')


### PR DESCRIPTION
I found out that the wallet was not running quickly enough on lower spec computers. 
So after some investigation I found out that the issue was regarding the Token Price Update into the SQlite db. I am changing it to bulk the insertion or update so it won't block the pool connection and other queries can run. 

Cheers