### PR TITLE
fix(token_price): duplicate tokens due to duplicate token price

### DIFF
--- a/src/main/migrations/20180726210124_clear_token_price.js
+++ b/src/main/migrations/20180726210124_clear_token_price.js
@@ -1,0 +1,5 @@
+exports.up = async (knex, Promise) => {
+	await knex('token_prices').truncate();
+};
+
+exports.down = async (knex, Promise) => {};


### PR DESCRIPTION
fixes #324 

Removes old data from token prices.
Next time a price is updated, it will be without duplicates

This is a temporary fix, permanent solution will be tracked in #325