### PR TITLE
feat: check for existing incorporation applications

### DIFF
--- a/src/renderer/kyc/application/current-application-container.jsx
+++ b/src/renderer/kyc/application/current-application-container.jsx
@@ -21,11 +21,12 @@ class CurrentApplicationComponent extends Component {
 	componentDidMount() {
 		if (!this.props.currentApplication) return;
 
+		const authenticated = true;
 		if (this.props.rpShouldUpdate) {
 			this.props.dispatch(
 				kycOperations.loadRelyingParty(
 					this.props.currentApplication.relyingPartyName,
-					true,
+					authenticated,
 					`/main/kyc/current-application/${
 						this.props.currentApplication.relyingPartyName
 					}`
@@ -125,9 +126,14 @@ const mapStateToProps = (state, props) => {
 	const currentApplication = kycSelectors.selectCurrentApplication(state);
 	if (!currentApplication) return {};
 	const relyingPartyName = props.match.params.rpName;
+	const authenticated = true;
 	return {
 		relyingParty: kycSelectors.relyingPartySelector(state, relyingPartyName),
-		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(state, relyingPartyName),
+		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(
+			state,
+			relyingPartyName,
+			authenticated
+		),
 		currentApplication,
 		requirements: kycSelectors.selectRequirementsForTemplate(
 			state,

--- a/src/renderer/marketplace/incorporation/common/program-price.jsx
+++ b/src/renderer/marketplace/incorporation/common/program-price.jsx
@@ -1,20 +1,9 @@
 import React from 'react';
 
-/*
-const formatNumber = number => {
-	// 4 decimal places for KEY values ?
-	const numeric = Math.abs(number).toFixed(2);
-	let splitNum = numeric.split('.');
-	// Format number with thousands separator
-	splitNum[0] = splitNum[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-	return splitNum.join('.');
-};
-*/
-
 const ProgramPrice = props => {
 	const { price, rate, label } = props;
 
-	if (!price) {
+	if (!price || !rate) {
 		return null;
 	}
 

--- a/src/renderer/marketplace/incorporation/detail/index.jsx
+++ b/src/renderer/marketplace/incorporation/detail/index.jsx
@@ -183,22 +183,27 @@ function TabContainer({ children }) {
 
 class IncorporationsDetailView extends Component {
 	state = {
-		selectedTab: 0
+		selectedTab: 0,
+		loading: false
 	};
 
 	async componentDidMount() {
 		window.scrollTo(0, 0);
 
-		if (!this.props.treaties || !this.props.treaties.length) {
+		const { treaties, rpShouldUpdate } = this.props;
+		const { countryCode } = this.props.match.params;
+		const notAuthenticated = false;
+
+		if (!treaties || !treaties.length) {
 			this.props.dispatch(
-				incorporationsOperations.loadIncorporationsTaxTreatiesOperation(
-					this.props.match.params.countryCode
-				)
+				incorporationsOperations.loadIncorporationsTaxTreatiesOperation(countryCode)
 			);
 		}
 
-		if (this.props.rpShouldUpdate) {
-			await this.props.dispatch(kycOperations.loadRelyingParty('incorporations', false));
+		if (rpShouldUpdate) {
+			await this.props.dispatch(
+				kycOperations.loadRelyingParty('incorporations', notAuthenticated)
+			);
 		}
 	}
 
@@ -207,11 +212,22 @@ class IncorporationsDetailView extends Component {
 	onBackClick = () => this.props.dispatch(push(`/main/marketplace-incorporation`));
 
 	onStartClick = () => {
+		const { rp } = this.props;
 		const { countryCode, companyCode, templateId } = this.props.match.params;
+		const payRoute = `/main/marketplace-incorporation/pay/${companyCode}/${countryCode}/${templateId}`;
+		const authenticated = true;
 
-		this.props.dispatch(
-			push(`/main/marketplace-incorporation/pay/${companyCode}/${countryCode}/${templateId}`)
-		);
+		// When clicking the start incorporations, we check if an authenticated kyc-chain session exists
+		// If it doesn't we trigger a new authenticated rp session and redirect to checkout route
+		this.setState({ loading: true }, async () => {
+			if (!rp.authenticated) {
+				await this.props.dispatch(
+					kycOperations.loadRelyingParty('incorporations', authenticated, payRoute)
+				);
+			} else {
+				await this.props.dispatch(push(payRoute));
+			}
+		});
 	};
 
 	onPayClick = () => {
@@ -231,9 +247,11 @@ class IncorporationsDetailView extends Component {
 	};
 
 	getLastApplication = () => {
+		const { rp } = this.props;
 		const { templateId } = this.props.match.params;
+		// For easy kyc testing, use the following test templateId
 		// const templateId = '5c6fadbf77c33d5c28718d7b';
-		if (!this.props.rp) return false;
+		if (!rp || !rp.authenticated) return false;
 
 		const { applications } = this.props.rp;
 		if (!applications || applications.length === 0) return false;
@@ -267,7 +285,12 @@ class IncorporationsDetailView extends Component {
 	canIncorporate = () => {
 		const { templateId } = this.props.match.params;
 		const price = this.getPrice();
-		return !!(templateId && price);
+
+		if (this.props.rp && this.props.rp.authenticated) {
+			return !!(templateId && price && !this.userHasApplied());
+		} else {
+			return !!(templateId && price);
+		}
 	};
 
 	renderPartialStatus = () => {
@@ -419,13 +442,19 @@ class IncorporationsDetailView extends Component {
 							</div>
 							<div className={classes.applyButton}>
 								<React.Fragment>
-									{this.canIncorporate() && (
+									{this.canIncorporate() && !this.state.loading && (
 										<Button
 											variant="contained"
 											size="large"
 											onClick={this.onStartClick}
 										>
 											Start Incorporation
+										</Button>
+									)}
+
+									{this.canIncorporate() && this.state.loading && (
+										<Button variant="contained" size="large" disabled>
+											Loading ...
 										</Button>
 									)}
 									<ProgramPrice
@@ -576,14 +605,18 @@ class IncorporationsDetailView extends Component {
 
 const mapStateToProps = (state, props) => {
 	const { companyCode, countryCode, templateId } = props.match.params;
-
+	const notAuthenticated = false;
 	return {
 		program: incorporationsSelectors.getIncorporationsDetails(state, companyCode),
 		treaties: incorporationsSelectors.getTaxTreaties(state, countryCode),
 		isLoading: incorporationsSelectors.getLoading(state),
 		keyRate: pricesSelectors.getRate(state, 'KEY', 'USD'),
 		rp: kycSelectors.relyingPartySelector(state, 'incorporations'),
-		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(state, 'incorporations'),
+		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(
+			state,
+			'incorporations',
+			notAuthenticated
+		),
 		requirements: kycSelectors.selectRequirementsForTemplate(
 			state,
 			'incorporations',

--- a/src/renderer/marketplace/incorporation/pay/process-started.jsx
+++ b/src/renderer/marketplace/incorporation/pay/process-started.jsx
@@ -77,8 +77,12 @@ const styles = theme => ({
 
 export class IncorporationProcessStarted extends React.Component {
 	async componentWillMount() {
+		const authenticated = true;
+
 		if (this.props.rpShouldUpdate) {
-			await this.props.dispatch(kycOperations.loadRelyingParty('incorporations'));
+			await this.props.dispatch(
+				kycOperations.loadRelyingParty('incorporations', authenticated)
+			);
 		}
 	}
 
@@ -112,8 +116,6 @@ export class IncorporationProcessStarted extends React.Component {
 
 	render() {
 		const { classes } = this.props;
-
-		console.log(this.props);
 
 		return (
 			<div className={classes.container}>
@@ -188,13 +190,18 @@ export class IncorporationProcessStarted extends React.Component {
 }
 
 const mapStateToProps = (state, props) => {
+	const authenticated = true;
 	return {
 		publicKey: getWallet(state).publicKey,
 		keyRate: pricesSelectors.getRate(state, 'KEY', 'USD'),
 		transaction: transactionSelectors.getTransaction(state),
 		currentApplication: kycSelectors.selectCurrentApplication(state),
 		rp: kycSelectors.relyingPartySelector(state, 'incorporations'),
-		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(state, 'incorporations'),
+		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(
+			state,
+			'incorporations',
+			authenticated
+		),
 		program: incorporationsSelectors.getIncorporationsDetails(
 			state,
 			props.match.params.companyCode


### PR DESCRIPTION
Some changes:
- Better handling of rpShouldUpdate, and session cache, differentiating between unauth and auth sessions
- Auth session is now triggered on click to "start incorporations" button
- User is redirected back if an existing application already exists.
- Should work with the hardware wallet flow.