### PR TITLE
Feat/change incorporation test price handling

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -18,6 +18,8 @@ const PRIMARY_TOKEN = process.env.PRIMARY_TOKEN_OVERRIDE
 	? process.env.PRIMARY_TOKEN_OVERRIDE.toUpperCase()
 	: null;
 
+const INCORPORATIONS_TEMPLATE_OVERRIDE = process.env.INCORPORATIONS_TEMPLATE_OVERRIDE;
+const INCORPORATIONS_PRICE_OVERRIDE = process.env.INCORPORATIONS_PRICE_OVERRIDE;
 const INCORPORATION_KYCC_INSTANCE = process.env.INCORPORATION_KYCC_INSTANCE;
 const MATOMO_SITE = process.env.MATOMO_SITE;
 
@@ -34,6 +36,8 @@ const common = {
 	userAgent: `SelfKeyIDW/${pkg.version}`,
 	incorporationsInstance:
 		INCORPORATION_KYCC_INSTANCE || 'https://apiv2.instance.kyc-chain.com/api/v2/',
+	incorporationsPriceOverride: INCORPORATIONS_PRICE_OVERRIDE,
+	incorporationsTemplateOverride: INCORPORATIONS_TEMPLATE_OVERRIDE,
 	constants: {
 		initialIdAttributes: {
 			REQ_1: { id: '1', attributeType: 'name' },
@@ -91,6 +95,7 @@ const dev = {
 	node: 'infura',
 	incorporationsInstance:
 		INCORPORATION_KYCC_INSTANCE || 'https://apiv2.instance.kyc-chain.com/api/v2/',
+
 	constants: {
 		primaryToken: PRIMARY_TOKEN || 'KI'
 	},

--- a/src/renderer/marketplace/incorporation/common/helpers.js
+++ b/src/renderer/marketplace/incorporation/common/helpers.js
@@ -1,0 +1,27 @@
+import config from 'common/config';
+
+const getIncorporationPrice = program => {
+	// Check for override ENV variables
+	if (config.incorporationsPriceOverride) return config.incorporationsPriceOverride;
+
+	let price = program['Wallet Price'];
+
+	if (config.dev) {
+		price = program['test_price'];
+	} else {
+		if (program['active_test_price']) {
+			price = program['test_price'];
+		}
+	}
+	return parseFloat(price.replace(/\$/, '').replace(/,/, ''));
+};
+
+const getTemplateID = program => {
+	// Check for override ENV variables
+	if (config.incorporationsTemplateOverride) return config.incorporationsTemplateOverride;
+
+	const templateID = config.dev ? program['test_template_id'] : program['template_id'];
+	return templateID;
+};
+
+export { getIncorporationPrice, getTemplateID };

--- a/src/renderer/marketplace/incorporation/common/index.js
+++ b/src/renderer/marketplace/incorporation/common/index.js
@@ -5,6 +5,7 @@ import TreatiesTable from './treaties-table';
 import CountryInfo from './country-info';
 import IncorporationsKYC from './kyc-requirements';
 import sanitize from './sanitize-airtable-html';
+import { getIncorporationPrice, getTemplateID } from './helpers';
 
 export {
 	FlagCountryName,
@@ -13,5 +14,7 @@ export {
 	TreatiesTable,
 	CountryInfo,
 	IncorporationsKYC,
-	sanitize
+	sanitize,
+	getIncorporationPrice,
+	getTemplateID
 };

--- a/src/renderer/marketplace/incorporation/common/program-price.jsx
+++ b/src/renderer/marketplace/incorporation/common/program-price.jsx
@@ -7,7 +7,6 @@ const ProgramPrice = props => {
 		return null;
 	}
 
-	// const numeric = parseInt(price.replace(/\$/, '').replace(/,/, ''));
 	const numeric = price;
 	const key = numeric / rate;
 	const formattedLabel = label ? `${label} ` : '';

--- a/src/renderer/marketplace/incorporation/common/program-price.jsx
+++ b/src/renderer/marketplace/incorporation/common/program-price.jsx
@@ -7,7 +7,8 @@ const ProgramPrice = props => {
 		return null;
 	}
 
-	const numeric = parseInt(price.replace(/\$/, '').replace(/,/, ''));
+	// const numeric = parseInt(price.replace(/\$/, '').replace(/,/, ''));
+	const numeric = price;
 	const key = numeric / rate;
 	const formattedLabel = label ? `${label} ` : '';
 

--- a/src/renderer/marketplace/incorporation/detail/index.jsx
+++ b/src/renderer/marketplace/incorporation/detail/index.jsx
@@ -18,7 +18,8 @@ import {
 	CountryInfo,
 	IncorporationsKYC,
 	ProgramPrice,
-	sanitize
+	sanitize,
+	getIncorporationPrice
 } from '../common';
 
 const styles = theme => ({
@@ -293,10 +294,13 @@ class IncorporationsDetailView extends Component {
 
 	getPrice = () => {
 		const { program } = this.props;
-		const price = program['active_test_price']
+		return getIncorporationPrice(program);
+		/*
+		const price = config.dev
 			? program['test_price']
-			: program['Wallet Price'];
+			: (program['active_test_price'] ? program['test_price'] : program['Wallet Price']);
 		return price;
+		*/
 	};
 
 	getLastApplication = () => {

--- a/src/renderer/marketplace/incorporation/detail/index.jsx
+++ b/src/renderer/marketplace/incorporation/detail/index.jsx
@@ -295,12 +295,6 @@ class IncorporationsDetailView extends Component {
 	getPrice = () => {
 		const { program } = this.props;
 		return getIncorporationPrice(program);
-		/*
-		const price = config.dev
-			? program['test_price']
-			: (program['active_test_price'] ? program['test_price'] : program['Wallet Price']);
-		return price;
-		*/
 	};
 
 	getLastApplication = () => {

--- a/src/renderer/marketplace/incorporation/pay/checkout.jsx
+++ b/src/renderer/marketplace/incorporation/pay/checkout.jsx
@@ -9,7 +9,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { CloseButtonIcon } from 'selfkey-ui';
 import { pricesSelectors } from 'common/prices';
-import { FlagCountryName, sanitize } from '../common';
+import { FlagCountryName, sanitize, getIncorporationPrice } from '../common';
 import { getLocale } from 'common/locale/selectors';
 import { getFiatCurrency } from 'common/fiatCurrency/selectors';
 import { getTokens } from 'common/wallet-tokens/selectors';
@@ -235,18 +235,21 @@ export class IncorporationCheckout extends React.Component {
 		return application.currentStatus === 3 || application.currentStatus === 8;
 	};
 
-	getIncorporationPrice = () => {
+	getPrice = () => {
 		const { program } = this.props;
-		const price = program['active_test_price']
+		return getIncorporationPrice(program);
+		/*
+		const price = config.dev
 			? program['test_price']
-			: program['Wallet Price'];
+			: (program['active_test_price'] ? program['test_price'] : program['Wallet Price']);
 		return parseInt(price.replace(/\$/, '').replace(/,/, ''));
+		*/
 	};
 
 	getPaymentParameters = _ => {
 		const { keyRate, ethRate, ethGasStationInfo, cryptoCurrency } = this.props;
 		const gasPrice = ethGasStationInfo.fast;
-		const price = this.getIncorporationPrice();
+		const price = this.getPrice();
 		const keyAmount = price / keyRate;
 		const gasLimit = FIXED_GAS_LIMIT_PRICE;
 		const ethFee = EthUnits.toEther(gasPrice * gasLimit, 'gwei');

--- a/src/renderer/marketplace/incorporation/pay/checkout.jsx
+++ b/src/renderer/marketplace/incorporation/pay/checkout.jsx
@@ -238,12 +238,6 @@ export class IncorporationCheckout extends React.Component {
 	getPrice = () => {
 		const { program } = this.props;
 		return getIncorporationPrice(program);
-		/*
-		const price = config.dev
-			? program['test_price']
-			: (program['active_test_price'] ? program['test_price'] : program['Wallet Price']);
-		return parseInt(price.replace(/\$/, '').replace(/,/, ''));
-		*/
 	};
 
 	getPaymentParameters = _ => {

--- a/src/renderer/marketplace/incorporation/pay/payment-confirmation.jsx
+++ b/src/renderer/marketplace/incorporation/pay/payment-confirmation.jsx
@@ -5,6 +5,7 @@ import config from 'common/config';
 import { Popup } from '../../../common/popup';
 import { Grid, Typography } from '@material-ui/core';
 import { HourGlassLargeIcon } from 'selfkey-ui';
+import { getIncorporationPrice } from '../common';
 import { PaymentConfirmationContent } from './payment-confirmation-content';
 import { incorporationsSelectors } from 'common/incorporations';
 import { transactionSelectors, transactionOperations } from 'common/transaction';
@@ -54,12 +55,15 @@ class IncorporationPaymentConfirmationComponent extends Component {
 		return program['Wallet Vendor Name'] || VENDOR_NAME;
 	};
 
-	getIncorporationPrice = _ => {
+	getPrice = _ => {
 		const { program } = this.props;
-		const price = program['active_test_price']
+		return getIncorporationPrice(program);
+		/*
+		const price = config.dev
 			? program['test_price']
-			: program['Wallet Price'];
+			: (program['active_test_price'] ? program['test_price'] : program['Wallet Price']);
 		return parseInt(price.replace(/\$/, '').replace(/,/, ''));
+		*/
 	};
 
 	getVendorWalletAddress = _ => {
@@ -72,7 +76,7 @@ class IncorporationPaymentConfirmationComponent extends Component {
 		const { keyRate, ethRate, ethGasStationInfo, cryptoCurrency, transaction } = this.props;
 		const gasPrice = ethGasStationInfo.fast;
 		const walletAddress = this.getVendorWalletAddress();
-		const price = this.getIncorporationPrice();
+		const price = this.getPrice();
 		const vendorName = this.getVendorName();
 		const keyAmount = price / keyRate;
 		const gasLimit = transaction.gasLimit ? transaction.gasLimit : FIXED_GAS_LIMIT_PRICE;

--- a/src/renderer/marketplace/incorporation/pay/payment-confirmation.jsx
+++ b/src/renderer/marketplace/incorporation/pay/payment-confirmation.jsx
@@ -58,12 +58,6 @@ class IncorporationPaymentConfirmationComponent extends Component {
 	getPrice = _ => {
 		const { program } = this.props;
 		return getIncorporationPrice(program);
-		/*
-		const price = config.dev
-			? program['test_price']
-			: (program['active_test_price'] ? program['test_price'] : program['Wallet Price']);
-		return parseInt(price.replace(/\$/, '').replace(/,/, ''));
-		*/
 	};
 
 	getVendorWalletAddress = _ => {

--- a/src/renderer/marketplace/incorporation/pay/process-started.jsx
+++ b/src/renderer/marketplace/incorporation/pay/process-started.jsx
@@ -94,8 +94,6 @@ export class IncorporationProcessStarted extends React.Component {
 	saveTransactionHash = async () => {
 		const { currentApplication, transaction, rp } = this.props;
 
-		console.log(this.props);
-
 		if (currentApplication && transaction) {
 			const application = rp.applications[rp.applications.length - 1];
 			await this.props.dispatch(

--- a/src/renderer/marketplace/incorporation/table/index.jsx
+++ b/src/renderer/marketplace/incorporation/table/index.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import PropTypes from 'prop-types';
-import conf from 'common/config';
 import { pricesSelectors } from 'common/prices';
 import { withStyles } from '@material-ui/core/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
@@ -14,7 +13,7 @@ import TableRow from '@material-ui/core/TableRow';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { LargeTableHeadRow, TagTableCell, Tag, IncorporationsIcon } from 'selfkey-ui';
 import { incorporationsOperations, incorporationsSelectors } from 'common/incorporations';
-import { FlagCountryName, ProgramPrice } from '../common';
+import { FlagCountryName, ProgramPrice, getIncorporationPrice, getTemplateID } from '../common';
 
 const styles = theme => ({
 	header: {
@@ -114,13 +113,6 @@ class IncorporationsTable extends Component {
 			this.props.dispatch(incorporationsOperations.loadIncorporationsOperation());
 		}
 	}
-
-	getPrice = program => {
-		const price = program['active_test_price']
-			? program['test_price']
-			: program['Wallet Price'];
-		return price;
-	};
 
 	generateRoute({ countryCode, companyCode, templateID }) {
 		let url = `${this.props.match.path}/details/${companyCode}/${countryCode}`;
@@ -230,7 +222,7 @@ class IncorporationsTable extends Component {
 									<TableCell className={classes.costCell}>
 										<ProgramPrice
 											label="$"
-											price={this.getPrice(inc)}
+											price={getIncorporationPrice(inc)}
 											rate={keyRate}
 										/>
 									</TableCell>
@@ -240,9 +232,7 @@ class IncorporationsTable extends Component {
 												this.onDetailsClick({
 													companyCode: inc['Company code'],
 													countryCode: inc['Country code'],
-													templateID: conf.dev
-														? inc['test_template_id']
-														: inc['template_id']
+													templateID: getTemplateID(inc)
 												});
 											}}
 										>


### PR DESCRIPTION
Adds the ability to override KYC template_id and price to facilitate incorporations testing (#962)
The following ENV variables are used:

- INCORPORATIONS_TEMPLATE_OVERRIDE
- INCORPORATIONS_PRICE_OVERRIDE

Template override should be the template_id string.
Price override should be the price in USD.
example:

`INCORPORATIONS_PRICE_OVERRIDE=0.55 yarn dev`

Do note the override is global in nature, when is set affects all programs/jurisdictions.
Also, in dev mode, the airtable test_price and test_template_id will always be used.