### PR TITLE
fix: add missing bracket on .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = tab
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-*.yml]
+[*.yml]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
This broke visual studio spaces/tabs...