### PR TITLE
Fix/1149 default icon exchanges

### DIFF
--- a/src/renderer/marketplace/services/service-details.jsx
+++ b/src/renderer/marketplace/services/service-details.jsx
@@ -218,6 +218,15 @@ const styles = theme => ({
 	},
 	leftAlign: {
 		textAlign: 'left'
+	},
+	defaultIcon: {
+		alignItems: 'center',
+		borderRadius: '8px',
+		color: '#FFFFFF',
+		display: 'flex',
+		height: '44px',
+		justifyContent: 'center',
+		width: '44px'
 	}
 });
 
@@ -426,6 +435,21 @@ class MarketplaceServiceDetailsComponent extends Component {
 
 	render() {
 		const { classes, item, backAction, relyingPartyName, templates } = this.props;
+		const getColors = () => ['#46dfba', '#46b7df', '#238db4', '#25a788', '#0e4b61'];
+		let random = Math.floor(Math.random() * 4);
+
+		const icon = !item.logo[0].url ? (
+			<img src={item.logo[0].url} className={classes.defaultIcon} />
+		) : (
+			<div
+				className={classes.defaultIcon}
+				style={{
+					backgroundColor: getColors()[random]
+				}}
+			>
+				{item.name.charAt(0)}
+			</div>
+		);
 
 		return (
 			<Grid container>
@@ -457,7 +481,7 @@ class MarketplaceServiceDetailsComponent extends Component {
 						className={classes.header}
 					>
 						<Grid item id="icon" className={classes.icon}>
-							<img src={item.logo[0].url} />
+							{icon}
 						</Grid>
 						<Grid item id="title" className={classes.title}>
 							<Grid container alignItems="center">

--- a/src/renderer/marketplace/services/service-details.jsx
+++ b/src/renderer/marketplace/services/service-details.jsx
@@ -438,7 +438,7 @@ class MarketplaceServiceDetailsComponent extends Component {
 		const getColors = () => ['#46dfba', '#46b7df', '#238db4', '#25a788', '#0e4b61'];
 		let random = Math.floor(Math.random() * 4);
 
-		const icon = !item.logo[0].url ? (
+		const icon = item.logo[0].url ? (
 			<img src={item.logo[0].url} className={classes.defaultIcon} />
 		) : (
 			<div

--- a/src/renderer/marketplace/services/services-list-item.jsx
+++ b/src/renderer/marketplace/services/services-list-item.jsx
@@ -4,6 +4,10 @@ import { Tag } from 'selfkey-ui';
 
 const styles = theme => ({
 	icon: {
+		alignItems: 'center',
+		borderRadius: '5px',
+		display: 'flex',
+		justifyContent: 'center',
 		height: '30px',
 		width: '30px'
 	},
@@ -94,6 +98,22 @@ export const MarketplaceServicesListItem = withStyles(styles)(
 			return status === 'Inactive' ? 'Coming Soon' : 'Details';
 		};
 
+		const getColors = () => ['#46dfba', '#46b7df', '#238db4', '#25a788', '#0e4b61'];
+		let random = Math.floor(Math.random() * 4);
+
+		const icon = logoUrl ? (
+			<img src={logoUrl} className={classes.icon} />
+		) : (
+			<div
+				className={classes.icon}
+				style={{
+					backgroundColor: getColors()[random]
+				}}
+			>
+				{name.charAt(0)}
+			</div>
+		);
+
 		const isNotExcludedResidents =
 			excludedResidents.length === 0 || excludedResidents[0] === 'None';
 
@@ -102,10 +122,8 @@ export const MarketplaceServicesListItem = withStyles(styles)(
 
 		return (
 			<TableRow key={name}>
-				<TableCell className={classes.noRightPadding}>
-					<img src={logoUrl} className={classes.icon} />
-				</TableCell>
-				<TableCell className={classes.lofasz}>
+				<TableCell className={classes.noRightPadding}>{icon}</TableCell>
+				<TableCell>
 					<Typography variant="h6">{name}</Typography>
 				</TableCell>
 				<TableCell>


### PR DESCRIPTION
Changes:
- Default icon to Exchanges list
- Default icon to Exchanges details page

<img width="447" alt="Screenshot 2019-05-02 at 11 34 36" src="https://user-images.githubusercontent.com/7461010/57067169-81e76880-6cce-11e9-9610-66a6ab2d7476.png">
<img width="318" alt="Screenshot 2019-05-02 at 11 34 49" src="https://user-images.githubusercontent.com/7461010/57067170-81e76880-6cce-11e9-9ef3-0e56cc8e3f79.png">
