### PR TITLE
fix: disable send button while Network Transaction Fee is not calculated

### DIFF
--- a/src/common/transaction/operations.js
+++ b/src/common/transaction/operations.js
@@ -39,6 +39,7 @@ const init = args => async dispatch => {
 			addressError: false,
 			sending: false,
 			status: '',
+			locked: false,
 			...args
 		})
 	);
@@ -98,6 +99,8 @@ const setTransactionFee = (newAddress, newAmount, newGasPrice, newGasLimit) => a
 		const amount = !newAmount ? transaction.amount : newAmount;
 		const walletAddress = state.wallet.publicKey;
 
+		dispatch(setLocked(true));
+
 		let gasPrice = state.ethGasStationInfo.ethGasStationInfo.average;
 		if (newGasPrice) {
 			gasPrice = newGasPrice;
@@ -142,6 +145,8 @@ const setTransactionFee = (newAddress, newAmount, newGasPrice, newGasLimit) => a
 				})
 			);
 		}
+
+		dispatch(setLocked(false));
 	} catch (e) {
 		log.error(e);
 	}
@@ -150,11 +155,16 @@ const setTransactionFee = (newAddress, newAmount, newGasPrice, newGasLimit) => a
 const setAmount = amount => async dispatch => {
 	await dispatch(
 		actions.updateTransaction({
-			amount
+			amount: amount
 		})
 	);
 	await dispatch(setTransactionFee(undefined, amount, undefined, undefined));
 };
+
+const setLocked = locked =>
+	actions.updateTransaction({
+		locked: locked
+	});
 
 const setGasPrice = gasPrice => async dispatch => {
 	await dispatch(
@@ -406,5 +416,6 @@ export default {
 	setTransactionFee: createAliasedAction(types.TRANSACTION_FEE_SET, setTransactionFee),
 	confirmSend: createAliasedAction(types.CONFIRM_SEND, confirmSend),
 	incorporationSend: createAliasedAction(types.INCORPORATION_SEND, incorporationSend),
-	setCryptoCurrency: createAliasedAction(types.CRYPTO_CURRENCY_SET, setCryptoCurrency)
+	setCryptoCurrency: createAliasedAction(types.CRYPTO_CURRENCY_SET, setCryptoCurrency),
+	setLocked: createAliasedAction(types.LOCKED_SET, setLocked)
 };

--- a/src/common/transaction/operations.js
+++ b/src/common/transaction/operations.js
@@ -155,7 +155,7 @@ const setTransactionFee = (newAddress, newAmount, newGasPrice, newGasLimit) => a
 const setAmount = amount => async dispatch => {
 	await dispatch(
 		actions.updateTransaction({
-			amount: amount
+			amount
 		})
 	);
 	await dispatch(setTransactionFee(undefined, amount, undefined, undefined));

--- a/src/common/transaction/reducers.js
+++ b/src/common/transaction/reducers.js
@@ -12,6 +12,7 @@ const initialState = {
 	transactionHash: '',
 	addressError: false,
 	sending: false,
+	locked: false,
 	cryptoCurrency: ''
 };
 

--- a/src/common/transaction/types.js
+++ b/src/common/transaction/types.js
@@ -12,6 +12,7 @@ const TRANSACTION_FEE_SET = 'app/transaction/fee/SET';
 const CONFIRM_SEND = 'app/transaction/comfirmSend';
 const INCORPORATION_SEND = 'app/transaction/incorporationSend';
 const CRYPTO_CURRENCY_SET = 'app/transaction/cryptoCurrency/SET';
+const LOCKED_SET = 'app/transaction/locked/SET';
 
 export {
 	TRANSACTION_UPDATE,
@@ -26,5 +27,6 @@ export {
 	TRANSACTION_FEE_SET,
 	CONFIRM_SEND,
 	INCORPORATION_SEND,
-	CRYPTO_CURRENCY_SET
+	CRYPTO_CURRENCY_SET,
+	LOCKED_SET
 };

--- a/src/renderer/transaction/send/advanced-transaction.jsx
+++ b/src/renderer/transaction/send/advanced-transaction.jsx
@@ -186,8 +186,9 @@ class TransactionSendBoxContainer extends Component {
 		TransactionSendBoxContainer.UPDATE_DELAY
 	);
 
-	withLock = targetFunction =>
-		over([() => this.props.dispatch(transactionOperations.setLocked(true)), targetFunction]);
+	lockTransaction = () => this.props.dispatch(transactionOperations.setLocked(true));
+
+	withLock = targetFunction => over([this.lockTransaction, targetFunction]);
 
 	handleConfirm = async () => {
 		await this.props.dispatch(appOperations.setGoBackPath(this.props.location.pathname));

--- a/src/renderer/transaction/send/containers/transaction-fee-box.jsx
+++ b/src/renderer/transaction/send/containers/transaction-fee-box.jsx
@@ -120,10 +120,6 @@ const styles = theme => ({
 });
 
 export class TransactionFeeBoxComponent extends Component {
-	timerToUpdateGasPrice = 0;
-	timerToUpdateGasLimit = 0;
-	TIME_FOR_INPUT_CHANGE = 1000;
-
 	state = {
 		showAdvanced: this.props.showAdvanced || false,
 		gasLimit: this.props.gasLimit,
@@ -154,26 +150,20 @@ export class TransactionFeeBoxComponent extends Component {
 
 	setGasLimit(event) {
 		const value = event.target.value;
-		if (this.timerToUpdateGasLimit) clearTimeout(this.timerToUpdateGasLimit);
 		this.setState({ ...this.state, gasLimit: Number(value) });
 
-		this.timerToUpdateGasLimit = window.setTimeout(() => {
-			if (this.props.changeGasLimitAction) {
-				this.props.changeGasLimitAction(value);
-			}
-		}, this.TIME_FOR_INPUT_CHANGE);
+		if (this.props.changeGasLimitAction) {
+			this.props.changeGasLimitAction(value);
+		}
 	}
 
 	setGasPrice(event) {
 		const value = event.target.value;
-		if (this.timerToUpdateGasPrice) clearTimeout(this.timerToUpdateGasPrice);
 		this.setState({ ...this.state, gasPrice: Number(value) });
 
-		this.timerToUpdateGasPrice = window.setTimeout(() => {
-			if (this.props.changeGasPriceAction) {
-				this.props.changeGasPriceAction(value);
-			}
-		}, this.TIME_FOR_INPUT_CHANGE);
+		if (this.props.changeGasPriceAction) {
+			this.props.changeGasPriceAction(value);
+		}
 	}
 
 	renderAdvancedContent() {


### PR DESCRIPTION
I've created a transaction attribute to indicate whether it's locked or not.

When the transaction is locked the Send button will be disabled

It can be used for any async operation to prevent users to send a transaction while this is being updated.

The transaction lock is used by:
- Gas price input change handler
- Gas limit input change handler
- setTransactionFee operation

I've also replaced some setTimeout's by a lodash debounce.