### PR TITLE
fix: incorrect usd value of Network Transaction Fee

### DIFF
--- a/src/common/transaction/selectors.js
+++ b/src/common/transaction/selectors.js
@@ -13,7 +13,7 @@ export const getTransaction = state => {
 	const transaction = state.transaction;
 	const { cryptoCurrency } = transaction;
 	transaction.amountUsd = getAmountUsd(transaction.amount, state, cryptoCurrency);
-	transaction.usdFee = getAmountUsd(transaction.ethFee, state, cryptoCurrency);
+	transaction.usdFee = getAmountUsd(transaction.ethFee, state, 'ETH');
 	const token = getTokens(state).filter(token => {
 		return token.symbol === cryptoCurrency;
 	})[0];


### PR DESCRIPTION
fix for #1077 

It was converting the ethFee into crypto other than ETH, looks like the cryptoCurrency must be always ETH here.

