### PR TITLE
fix: update transaction history to display sending status

### DIFF
--- a/src/main/blockchain/tx-history-service.js
+++ b/src/main/blockchain/tx-history-service.js
@@ -316,12 +316,7 @@ export class TxHistoryService {
 		}
 	}
 	async removeNotMinedPendingTxs(address) {
-		let nonce = await this.web3Service.waitForTicket({
-			method: 'getTransactionCount',
-			args: [address, 'pending']
-		});
-
-		return TxHistory.removeNotMinedPendingTxsByPublicKey(address, +nonce);
+		return TxHistory.updatePendingTxsByPublicKey(address);
 	}
 
 	startSyncingJob() {

--- a/src/main/blockchain/tx-history.js
+++ b/src/main/blockchain/tx-history.js
@@ -167,7 +167,9 @@ export class TxHistory extends BaseModel {
 		const status = await web3Service.getTransactionStatus(tx);
 
 		if (status === 'failed') {
-			await this.removeTxById(localTx.id);
+			await this.query().patchAndFetchById(localTx.id, {
+				isError: 1
+			});
 		} else if (status === 'success') {
 			await this.query().patchAndFetchById(localTx.id, {
 				blockHash: tx.blockHash,

--- a/src/main/blockchain/web3-service.js
+++ b/src/main/blockchain/web3-service.js
@@ -219,15 +219,21 @@ export class Web3Service {
 		}
 		return num;
 	}
-	async checkTransactionStatus(hash) {
-		let tx = await this.getTransaction(hash);
+
+	/**
+	 * Get transaction status
+	 *
+	 * @param {Transaction} tx transaction
+	 * @return {string} status
+	 */
+	async getTransactionStatus(tx) {
 		if (!tx) {
 			return 'pending';
 		}
 		if (!tx.blockNumber) {
 			return 'processing';
 		}
-		let receipt = await this.getTransactionReceipt(hash);
+		let receipt = await this.getTransactionReceipt(tx.hash);
 		let status = receipt.status;
 		if (typeof status !== 'boolean') {
 			status = this.web3.utils.hexToNumber(receipt.status);
@@ -236,6 +242,17 @@ export class Web3Service {
 			return 'failed';
 		}
 		return 'success';
+	}
+
+	/**
+	 * Given a transaction hash return the transaction status
+	 *
+	 * @param {string} hash
+	 * @return {string} status
+	 */
+	async checkTransactionStatus(hash) {
+		const tx = await this.getTransaction(hash);
+		return this.getTransactionStatus(tx);
 	}
 
 	async sendSignedTransaction(contactMethodInstance, contractAdress, args, wallet) {

--- a/src/renderer/transaction/transactions-history/index.jsx
+++ b/src/renderer/transaction/transactions-history/index.jsx
@@ -140,13 +140,18 @@ const getCustomStatusText = (transaction, sent) => {
 		} else {
 			return `Failed to receive ${cryptoType}`;
 		}
-	} else {
-		if (sent) {
-			return `Sent ${cryptoType}`;
-		} else {
-			return `Received ${cryptoType}`;
-		}
 	}
+
+	const isPending = !transaction.blockHash;
+	let label;
+
+	if (sent) {
+		label = isPending ? 'Sending' : 'Sent';
+	} else {
+		label = isPending ? 'Receiving' : 'Received';
+	}
+
+	return `${label} ${cryptoType}`;
 };
 
 const getCustomValue = (transaction, sent) => {


### PR DESCRIPTION
fix for #1102

I've updated the transaction history service. The old implementation was removing all pending transactions from the list, and also was not receiving updates from the blockchain. The user would have to hard reload the list to see new transactions.

The new implementation should:
* Keep pending transactions in the db
* Check all the pending transactions in the blockchain to receive updates
* Remove failed transactions from the db.
* I've also fixed a bug related to uppercase "from" and "to" attributes being saved into the db. It was breaking the search results.
