### PR TITLE
Feat/basic feature flags

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -112,7 +112,10 @@ const common = {
 		'https://blog.selfkey.org/',
 		'https://selfkey.org/wp-content/uploads/2017/11/selfkey-whitepaper-en.pdf',
 		'https://t.me/selfkeyfoundation'
-	]
+	],
+	features: {
+		paymentContract: true
+	}
 };
 
 const dev = {

--- a/src/common/feature-flags.js
+++ b/src/common/feature-flags.js
@@ -1,8 +1,14 @@
 import config from './config';
 
 const featureIsEnabled = featureName => {
-	if (process.env.hasOwnProperty('FEATURE_PAYMENT_CONTRACT')) {
-		return !!process.env.FEATURE_PAYMENT_CONTRACT;
+	const snakeCase = featureName
+		.split(/(?=[A-Z])/)
+		.join('_')
+		.toUpperCase();
+
+	// env variables format for features is FEATURE_NAME_IN_SNAKE_CASE
+	if (process.env.hasOwnProperty(`FEATURE_${snakeCase}`)) {
+		return !!process.env[`FEATURE_${snakeCase}`];
 	}
 	return !!config.features[featureName];
 };

--- a/src/common/feature-flags.js
+++ b/src/common/feature-flags.js
@@ -1,5 +1,10 @@
 import config from './config';
 
-const featureIsEnabled = featureName => !!config.features[featureName];
+const featureIsEnabled = featureName => {
+	if (process.env.hasOwnProperty('FEATURE_PAYMENT_CONTRACT')) {
+		return !!process.env.FEATURE_PAYMENT_CONTRACT;
+	}
+	return !!config.features[featureName];
+};
 
 export { featureIsEnabled };

--- a/src/common/feature-flags.js
+++ b/src/common/feature-flags.js
@@ -1,0 +1,5 @@
+import config from './config';
+
+const featureIsEnabled = featureName => !!config.features[featureName];
+
+export { featureIsEnabled };


### PR DESCRIPTION
We have decided to release the 1st version BAM without payment contracts
To facilitate this and keep existing payment code, I created a simple implementation of feature flags, to easily activate/deactivate features in prod/dev.

Usage is as follows:
```
import { featureIsEnabled } from 'common/feature-flags';
if (featureIsEnabled('paymentContract')) {
  // do stuff
}
```

Features are defined in config object, and can be have different values per env:
```
common = {
  ...
  features: {
    paymentContract: true
  }
}

prod = {
  ...
  features: {
     paymentContract: false
  }
}
```

Features can also be changed via env variables, in this case is FEATURE_PAYMENT_CONTRACT