### PR TITLE
fix: button text size in toolbar dropdown

### DIFF
--- a/src/renderer/wallet/main/toolbar.jsx
+++ b/src/renderer/wallet/main/toolbar.jsx
@@ -237,6 +237,7 @@ const ProfileList = withStyles(profileStyle)(
 										variant="outlined"
 										size="small"
 										onClick={onClickCorporate}
+										className={classes.smallButton}
 									>
 										New Corporate Profile
 									</Button>


### PR DESCRIPTION
Fixed this button text size, the classname was missed.
##### Before
<img width="225" alt="Screenshot 2019-09-24 at 15 44 13" src="https://user-images.githubusercontent.com/7461010/65516936-2ec2bc00-dee2-11e9-8936-e0a4dc28c601.png">

##### After
<img width="231" alt="Screenshot 2019-09-24 at 15 43 50" src="https://user-images.githubusercontent.com/7461010/65516935-2ec2bc00-dee2-11e9-8fb6-dff1faf3905d.png">
