### PR TITLE
fix: handle empty rp config object

### DIFF
--- a/src/common/kyc/index.js
+++ b/src/common/kyc/index.js
@@ -339,6 +339,10 @@ const loadRelyingPartyOperation = (
 	}
 
 	const config = rp.relyingPartyConfig;
+	if (!config.rootEndpoint) {
+		console.log('Empty RP config object');
+		return;
+	}
 
 	try {
 		await dispatch(kycActions.setCancelRoute(cancelRoute));


### PR DESCRIPTION
Prevents an error when going through all existing RPs to find open applications.