### PR TITLE
fix: token box address long and font size

### DIFF
--- a/src/renderer/dashboard/token-box.jsx
+++ b/src/renderer/dashboard/token-box.jsx
@@ -12,9 +12,6 @@ const styles = theme => ({
 		padding: 20,
 		maxWidth: 350
 	},
-	address: {
-		fontSize: 10.5
-	},
 	tokenBoxHeader: {
 		display: 'flex',
 		justifyContent: 'space-evenly',
@@ -26,6 +23,15 @@ const styles = theme => ({
 	},
 	marginSpace: {
 		marginTop: '7px'
+	},
+	publicKey: {
+		color: '#93B0C1',
+		fontSize: '12px',
+		lineHeight: '19px',
+		maxWidth: '250px',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap'
 	}
 });
 
@@ -64,13 +70,9 @@ const TokenBox = props => {
 				</Grid>
 				<Grid xs={12} container justify="space-between" className={classes.marginSpace}>
 					<Grid item>
-						<Typography
-							className={classes.publicKey}
-							variant="subtitle2"
-							color="secondary"
-						>
+						<p className={classes.publicKey} title={address}>
 							{address}
-						</Typography>
+						</p>
 					</Grid>
 					<Grid item>
 						<Copy text={address} />


### PR DESCRIPTION
#### Original:
<img width="1098" alt="Screenshot 2019-10-16 at 14 56 26" src="https://user-images.githubusercontent.com/7461010/66924188-755f8e00-f02a-11e9-9b9d-6f03b469a739.png">

#### Fixed: 
<img width="1093" alt="Screenshot 2019-10-16 at 15 11 42" src="https://user-images.githubusercontent.com/7461010/66924209-80b2b980-f02a-11e9-9df7-082a660ab742.png">
