### PR TITLE
fix: match by schema instead of label name

### DIFF
--- a/src/renderer/corporate/common/corporate-details.jsx
+++ b/src/renderer/corporate/common/corporate-details.jsx
@@ -58,7 +58,11 @@ const renderAttr = attr =>
 	);
 
 const renderAddressAtr = profile => {
-	const addressAtr = profile.allAttributes.find(a => a.name === 'Address');
+	const addressAtr = profile.allAttributes.find(
+		attr =>
+			attr.type.content.$id ===
+			'http://platform.selfkey.org/schema/attribute/physical-address.json'
+	);
 	if (addressAtr) {
 		const value = addressAtr.data.value;
 		return renderAttr(value ? `${value.address_line_1} ${value.address_line_2}` : '');


### PR DESCRIPTION
Previous fix to #1750 was not well thought.
It should find address by schema id instead of name.