### PR TITLE
fix: get payment hash from order on marketplace transactions

### DIFF
--- a/src/common/marketplace/orders/index.js
+++ b/src/common/marketplace/orders/index.js
@@ -256,8 +256,8 @@ const checkOrderAllowanceOperation = orderId => async (dispatch, getState) => {
 };
 
 const finishCurrentOrderOperation = () => async (dispatch, getState) => {
-	const { completeUrl } = ordersSelectors.getCurrentOrder(getState());
-	await dispatch(push(completeUrl));
+	const { completeUrl, orderId } = ordersSelectors.getCurrentOrder(getState());
+	await dispatch(push(`${completeUrl}/${orderId}`));
 	await dispatch(ordersOperations.setCurrentOrderAction(null));
 };
 

--- a/src/renderer/marketplace/bank-accounts/checkout/payment-complete-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/checkout/payment-complete-container.jsx
@@ -6,6 +6,7 @@ import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { marketplaceSelectors } from 'common/marketplace';
 import { transactionSelectors } from 'common/transaction';
+import { ordersSelectors } from 'common/marketplace/orders';
 import { MarketplaceBankAccountsComponent } from '../common/marketplace-bank-accounts-component';
 import { BankAccountsPaymentComplete } from './payment-complete';
 
@@ -17,13 +18,13 @@ class BankAccountsPaymentCompleteContainer extends MarketplaceBankAccountsCompon
 	}
 
 	async componentDidMount() {
-		const { transaction, jurisdiction, vendorId } = this.props;
+		const { order, jurisdiction, vendorId } = this.props;
 
 		this.saveTransactionHash();
 		this.clearRelyingParty();
 
 		this.trackEcommerceTransaction({
-			transactionHash: transaction.transactionHash,
+			transactionHash: order.paymentHash,
 			price: jurisdiction.price,
 			code: jurisdiction.data.accountCode,
 			jurisdiction: jurisdiction.data.region,
@@ -32,15 +33,18 @@ class BankAccountsPaymentCompleteContainer extends MarketplaceBankAccountsCompon
 	}
 
 	saveTransactionHash = async () => {
-		const { transaction, jurisdiction, vendorId } = this.props;
+		const { order, transaction, jurisdiction, vendorId } = this.props;
 		const application = this.getLastApplication();
 
-		if (!this.userHasPaid() && transaction) {
+		const transactionHash = order ? order.paymentHash : transaction.transactionHash;
+		const amountKey = order ? order.amount : transaction.amount;
+
+		if (!this.userHasPaid() && transactionHash) {
 			await this.props.dispatch(
 				kycOperations.updateRelyingPartyKYCApplicationPayment(
 					vendorId,
 					application.id,
-					transaction.transactionHash
+					transactionHash
 				)
 			);
 
@@ -49,16 +53,16 @@ class BankAccountsPaymentCompleteContainer extends MarketplaceBankAccountsCompon
 					id: application.id,
 					payments: {
 						amount: jurisdiction.price,
-						amountKey: transaction.amount,
-						transactionHash: transaction.transactionHash,
+						amountKey,
+						transactionHash,
 						date: Date.now(),
 						status: 'Sent KEY'
 					}
 				})
 			);
 		} else {
-			// TODO: what to do if no transaction or currentApplication exists?
-			console.error('No current application or transaction');
+			// TODO: what to do if no order or currentApplication exists?
+			console.error('No current application or order');
 			this.props.dispatch(push(this.cancelRoute()));
 		}
 	};
@@ -85,7 +89,7 @@ class BankAccountsPaymentCompleteContainer extends MarketplaceBankAccountsCompon
 }
 
 const mapStateToProps = (state, props) => {
-	const { accountCode, vendorId, templateId } = props.match.params;
+	const { accountCode, vendorId, templateId, orderId } = props.match.params;
 	const authenticated = true;
 	return {
 		accountCode,
@@ -95,6 +99,7 @@ const mapStateToProps = (state, props) => {
 		transaction: transactionSelectors.getTransaction(state),
 		address: getWallet(state).address,
 		currentApplication: kycSelectors.selectCurrentApplication(state),
+		order: ordersSelectors.getOrder(state, orderId),
 		rp: kycSelectors.relyingPartySelector(state, vendorId),
 		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(
 			state,

--- a/src/renderer/marketplace/bank-accounts/common/account-option.jsx
+++ b/src/renderer/marketplace/bank-accounts/common/account-option.jsx
@@ -186,7 +186,7 @@ export const BankingAccountOption = withStyles(styles)(
 				<Grid item xs={gridSize}>
 					<ExpansionPanel
 						expanded={isOpen}
-						onChange={(e, expanded) => toggleOpen(expanded)}
+						onChange={(e, expanded) => toggleOpen && toggleOpen(expanded)}
 						style={{ borderRadius: '0 4px 4px 0' }}
 					>
 						<ExpansionPanelSummary expandIcon={<ExpandLessIcon />}>

--- a/src/renderer/marketplace/bank-accounts/common/option-selection.jsx
+++ b/src/renderer/marketplace/bank-accounts/common/option-selection.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-
 import { withStyles } from '@material-ui/core/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { CloseButtonIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/bank-accounts/index.jsx
+++ b/src/renderer/marketplace/bank-accounts/index.jsx
@@ -32,7 +32,7 @@ class MarketplaceBankAccountsComponent extends Component {
 					component={BankAccountsPaymentContainer}
 				/>
 				<Route
-					path={`${path}/payment-complete/:accountCode/:countryCode/:templateId/:vendorId`}
+					path={`${path}/payment-complete/:accountCode/:countryCode/:templateId/:vendorId/:orderId?`}
 					component={BankAccountsPaymentCompleteContainer}
 				/>
 				<Route

--- a/src/renderer/marketplace/incorporation/checkout/incorporations-payment-complete-container.jsx
+++ b/src/renderer/marketplace/incorporation/checkout/incorporations-payment-complete-container.jsx
@@ -7,6 +7,7 @@ import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { incorporationsSelectors } from 'common/incorporations';
 import { transactionSelectors } from 'common/transaction';
+import { ordersSelectors } from 'common/marketplace/orders';
 import { MarketplaceIncorporationsComponent } from '../common/marketplace-incorporations-component';
 import { MarketplaceProcessStarted } from '../../common/marketplace-process-started';
 
@@ -20,13 +21,13 @@ class IncorporationsPaymentCompleteContainer extends MarketplaceIncorporationsCo
 	}
 
 	async componentDidMount() {
-		const { transaction, companyCode, program, vendorId } = this.props;
+		const { order, companyCode, program, vendorId } = this.props;
 
 		this.saveTransactionHash();
 		this.clearRelyingParty();
 
 		this.trackEcommerceTransaction({
-			transactionHash: transaction.transactionHash,
+			transactionHash: order.paymentHash,
 			price: program.price,
 			code: companyCode,
 			jurisdiction: program.data.region,
@@ -35,15 +36,18 @@ class IncorporationsPaymentCompleteContainer extends MarketplaceIncorporationsCo
 	}
 
 	saveTransactionHash = async () => {
-		const { transaction, program, vendorId } = this.props;
+		const { order, transaction, program, vendorId } = this.props;
 		const application = this.getLastApplication();
 
-		if (!this.userHasPaid() && transaction) {
+		const transactionHash = order ? order.paymentHash : transaction.transactionHash;
+		const amountKey = order ? order.amount : transaction.amount;
+
+		if (!this.userHasPaid() && transactionHash) {
 			await this.props.dispatch(
 				kycOperations.updateRelyingPartyKYCApplicationPayment(
 					vendorId,
 					application.id,
-					transaction.transactionHash
+					transactionHash
 				)
 			);
 
@@ -52,16 +56,16 @@ class IncorporationsPaymentCompleteContainer extends MarketplaceIncorporationsCo
 					id: application.id,
 					payments: {
 						amount: program.price,
-						amountKey: transaction.amount,
-						transactionHash: transaction.transactionHash,
+						amountKey,
+						transactionHash,
 						date: Date.now(),
 						status: 'Sent KEY'
 					}
 				})
 			);
 		} else {
-			// TODO: what to do if no transaction or currentApplication exists?
-			console.error('No current application or transaction');
+			// TODO: what to do if no order or currentApplication exists?
+			console.error('No current application or order');
 			this.props.dispatch(push(this.cancelRoute()));
 		}
 	};
@@ -106,7 +110,7 @@ class IncorporationsPaymentCompleteContainer extends MarketplaceIncorporationsCo
 }
 
 const mapStateToProps = (state, props) => {
-	const { companyCode, vendorId } = props.match.params;
+	const { companyCode, vendorId, orderId } = props.match.params;
 	const authenticated = true;
 	return {
 		companyCode,
@@ -115,6 +119,7 @@ const mapStateToProps = (state, props) => {
 		transaction: transactionSelectors.getTransaction(state),
 		address: getWallet(state).address,
 		currentApplication: kycSelectors.selectCurrentApplication(state),
+		order: ordersSelectors.getOrder(state, orderId),
 		rp: kycSelectors.relyingPartySelector(state, vendorId),
 		rpShouldUpdate: kycSelectors.relyingPartyShouldUpdateSelector(
 			state,

--- a/src/renderer/marketplace/incorporation/index.jsx
+++ b/src/renderer/marketplace/incorporation/index.jsx
@@ -32,7 +32,7 @@ class MarketplaceIncorporationComponent extends Component {
 					component={IncorporationsPaymentContainer}
 				/>
 				<Route
-					path={`${path}/payment-complete/:companyCode/:countryCode/:templateId/:vendorId`}
+					path={`${path}/payment-complete/:companyCode/:countryCode/:templateId/:vendorId/:orderId?`}
 					component={IncorporationsPaymentCompleteContainer}
 				/>
 			</div>


### PR DESCRIPTION
Fixes #1706.
Uses order instead of transaction model for processing marketplace payments.
Prevents error when navigating away from checkout flow in mid-process.