### PR TITLE
fix: removed left padding from fiat payment cells

### DIFF
--- a/src/renderer/marketplace/exchanges/exchanges-list-item.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-list-item.jsx
@@ -45,7 +45,7 @@ const styles = theme => ({
 		wordBreak: 'break-word'
 	},
 	excluded: {
-		padding: '10px',
+		padding: '10px 10px 10px 0',
 		whiteSpace: 'normal',
 		width: '100px',
 		wordBreak: 'break-word'


### PR DESCRIPTION
Changes:
<img width="110" alt="Screenshot 2019-11-18 at 21 36 12" src="https://user-images.githubusercontent.com/7461010/69091856-76ca0f00-0a4b-11ea-9986-0367624065c7.png">
