### PR TITLE
fix: select correct parentId when editing an existing member

### DIFF
--- a/src/renderer/corporate/member/corporate-member-container.jsx
+++ b/src/renderer/corporate/member/corporate-member-container.jsx
@@ -294,6 +294,7 @@ const mapStateToProps = (state, props) => {
 	let { parentId, identityId } = props.match.params;
 
 	const profile = identityId ? identitySelectors.selectProfile(state, { identityId }) : false;
+	parentId = profile && profile.identity.parentId ? profile.identity.parentId : parentId;
 	const parentProfile = identitySelectors.selectCorporateProfile(state, {
 		identityId: parentId
 	});


### PR DESCRIPTION
#1875 