### PR TITLE
fix: multiple corporate member fixes

### DIFF
--- a/src/common/identity/operations.js
+++ b/src/common/identity/operations.js
@@ -447,22 +447,26 @@ const updateMemberProfileOperation = (data, identityId, onComplete) => async (
 	update.id = identityId;
 	const identity = await dispatch(identityOperations.updateIdentityOperation(update));
 
-	const attributes = identitySelectors.selectAttributeTypesFiltered(getState(), {
+	const attributes = identitySelectors.selectIdAttributes(getState(), {
+		identityId
+	});
+
+	const idAttributeTypes = identitySelectors.selectAttributeTypesFiltered(getState(), {
 		entityType: identity.type
 	});
+
+	const getTypeId = url => {
+		return idAttributeTypes.find(idAttributeType => idAttributeType.url === url).id;
+	};
+
 	const updatedAttributes = attributeList.map(attr => {
-		const attribute = attributes.find(a => a.url === attr.type) || {};
+		const attribute = attributes.find(a => a.typeId === getTypeId(attr.type)) || {};
 		attr = { ...attr };
 		attr.id = attribute.id;
 		attr.value = data[attr.key];
 		return attr;
 	});
-	const idAttributeTypes = identitySelectors.selectAttributeTypesFiltered(getState(), {
-		entityType: identity.type
-	});
-	const getTypeId = url => {
-		return idAttributeTypes.find(idAttributeType => idAttributeType.url === url).id;
-	};
+
 	for (const attr of updatedAttributes) {
 		if (typeof attr.value !== 'undefined') {
 			const value = attr.value || '';

--- a/src/renderer/corporate/common/corporate-members.jsx
+++ b/src/renderer/corporate/common/corporate-members.jsx
@@ -23,7 +23,8 @@ import {
 	getMemberPositions,
 	getProfileJurisdiction,
 	getProfileResidency,
-	getMemberEquity
+	getMemberEquity,
+	getProfileEmail
 } from './common-helpers.jsx';
 
 const styles = theme => ({
@@ -87,6 +88,9 @@ const styles = theme => ({
 		maxWidth: '1em',
 		padding: '0',
 		textAlign: 'center'
+	},
+	email: {
+		textTransform: 'lowercase'
 	}
 });
 
@@ -136,9 +140,11 @@ const CorporateMembers = withStyles(styles)(props => {
 							<TableCell>
 								<Typography variant="overline">Shares</Typography>
 							</TableCell>
+							{/* }
 							<TableCell>
 								<Typography variant="overline">Selfkey user</Typography>
 							</TableCell>
+							*/}
 							<TableCell align="right">
 								<Typography variant="overline">Actions</Typography>
 							</TableCell>
@@ -168,6 +174,12 @@ const CorporateMembers = withStyles(styles)(props => {
 											<Typography variant="h6" className={classes.capitalize}>
 												{getProfileName(member)}
 											</Typography>
+											<Typography
+												variant="overline"
+												className={classes.email}
+											>
+												{getProfileEmail(member)}
+											</Typography>
 										</TableCell>
 										<TableCell>
 											<Typography variant="h6" className={classes.capitalize}>
@@ -193,12 +205,14 @@ const CorporateMembers = withStyles(styles)(props => {
 										</TableCell>
 										<TableCell>
 											<Typography variant="h6">
-												{getMemberEquity(member)}
+												{getMemberEquity(member)}%
 											</Typography>
 										</TableCell>
+										{/*
 										<TableCell>
 											<Typography variant="h6">Invite</Typography>
 										</TableCell>
+										*/}
 										<TableCell>
 											<IconButton
 												id="editButton"

--- a/src/renderer/corporate/member/corporate-member-container.jsx
+++ b/src/renderer/corporate/member/corporate-member-container.jsx
@@ -194,10 +194,11 @@ class CorporateMemberContainerComponent extends PureComponent {
 		const positionsWithEquity = this.props.positionsWithEquity
 			? this.props.positionsWithEquity
 			: [];
-		return (
-			selectedPositions.some(p => positionsWithEquity.includes(p)) &&
-			(!isNaN(number) && number >= 0 && number <= 100)
-		);
+		if (selectedPositions.some(p => positionsWithEquity.includes(p))) {
+			return !isNaN(number) && number >= 0 && number <= 100;
+		} else {
+			return true;
+		}
 	};
 
 	validateAttributeDid = did => true;
@@ -310,7 +311,6 @@ const mapStateToProps = (state, props) => {
 	if (!parentProfile || parentProfile.identity.type !== 'corporate') {
 		throw new Error(`Invalid parent identity, requires 'corporate' type`);
 	}
-
 	return {
 		parentId,
 		parentProfile,
@@ -329,10 +329,12 @@ const mapStateToProps = (state, props) => {
 		}),
 		companies: [
 			parentProfile,
-			...identitySelectors.selectChildrenProfilesByType(state, {
-				identityId: parentId,
-				type: 'corporate'
-			})
+			...identitySelectors
+				.selectChildrenProfilesByType(state, {
+					identityId: parentId,
+					type: 'corporate'
+				})
+				.filter(c => c.identity.id !== +identityId)
 		],
 		member: identityId ? memberData(state, identityId) : false
 	};


### PR DESCRIPTION
Fixes a number of issues:

- Update member error
- Adds missing email below member name in members screen
- Hides (for now) the invite user column
- Fixes issue with validation of equity
- Fixes issue with showing current member company as a possible parent when editing