### PR TITLE
refactor: explicitly use material-ui/styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"@material-ui/core": "4.9.9",
 		"@material-ui/icons": "4.9.1",
 		"@material-ui/lab": "4.0.0-alpha.48",
+		"@material-ui/styles": "4.9.6",
 		"@sentry/electron": "0.17.1",
 		"@trodi/electron-splashscreen": "0.3.4",
 		"ajv": "6.10.0",
@@ -325,6 +326,7 @@
 			"connected-react-router",
 			"@material-ui/core",
 			"@material-ui/icons",
+			"@material-ui/styles",
 			"flag-icon-css/css/flag-icon.css",
 			"fs-extra",
 			"node-machine-id"
@@ -364,6 +366,7 @@
 				"connected-react-router",
 				"@material-ui/core",
 				"@material-ui/icons",
+				"@material-ui/styles",
 				"flag-icon-css/css/flag-icon.css",
 				"fs-extra",
 				"node-machine-id",

--- a/src/renderer/address-book/add/index.jsx
+++ b/src/renderer/address-book/add/index.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { StyledButton } from 'selfkey-ui';
 import { addressBookSelectors, addressBookOperations } from 'common/address-book';
 import { Grid, Input } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { push } from 'connected-react-router';
 import { Popup } from '../../common';
 

--- a/src/renderer/address-book/edit/index.jsx
+++ b/src/renderer/address-book/edit/index.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { StyledButton } from 'selfkey-ui';
 import { addressBookSelectors, addressBookOperations } from 'common/address-book';
 import { Grid, Input } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { push } from 'connected-react-router';
 import { Popup } from '../../common';
 

--- a/src/renderer/address-book/main/index.jsx
+++ b/src/renderer/address-book/main/index.jsx
@@ -10,7 +10,7 @@ import {
 	AddressBookIcon,
 	SmallTableHeadRow
 } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import {
 	Grid,
 	Typography,

--- a/src/renderer/attributes/create-attribute.jsx
+++ b/src/renderer/attributes/create-attribute.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React, { PureComponent } from 'react';
-import { withStyles, Divider, Button, Grid, Select, Typography, Input } from '@material-ui/core';
+import { Divider, Button, Grid, Select, Typography, Input } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { identityAttributes, jsonSchema } from 'common/identity/utils';
 import Form from 'react-jsonschema-form-material-theme';
 import transformErrors from './transform-errors';

--- a/src/renderer/attributes/delete-attribute.jsx
+++ b/src/renderer/attributes/delete-attribute.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 
-import { Input, Typography, withStyles, Button, Grid } from '@material-ui/core';
+import { Input, Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../common/popup';
 
 const styles = theme => ({

--- a/src/renderer/attributes/delete-member.jsx
+++ b/src/renderer/attributes/delete-member.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, withStyles, Button, Grid } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../common/popup';
 
 const styles = theme => ({

--- a/src/renderer/attributes/edit-attribute.jsx
+++ b/src/renderer/attributes/edit-attribute.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React, { PureComponent } from 'react';
-import { Input, withStyles, Typography, Divider, Button, Grid } from '@material-ui/core';
+import { Input, Typography, Divider, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../common/popup';
 import { identityAttributes, jsonSchema } from 'common/identity/utils';
 import Form from 'react-jsonschema-form-material-theme';

--- a/src/renderer/attributes/edit-avatar.jsx
+++ b/src/renderer/attributes/edit-avatar.jsx
@@ -1,6 +1,7 @@
 /* global FileReader */
 import React, { PureComponent } from 'react';
-import { ButtonBase, withStyles, Button, Grid, Divider } from '@material-ui/core';
+import { ButtonBase, Button, Grid, Divider } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { HexagonAvatar } from '../individual/common/hexagon-avatar';
 import { Popup } from '../common/popup';
 

--- a/src/renderer/auto-update/auto-update-progress.jsx
+++ b/src/renderer/auto-update/auto-update-progress.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { withStyles, Grid, Typography, Button, LinearProgress } from '@material-ui/core';
+import { Grid, Typography, Button, LinearProgress } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../common';
 import { DownloadIcon2 } from 'selfkey-ui';
 

--- a/src/renderer/auto-update/auto-update.jsx
+++ b/src/renderer/auto-update/auto-update.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { withStyles, Grid, Typography, Button } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../common';
 import { DownloadIcon2 } from 'selfkey-ui';
 

--- a/src/renderer/certifiers/become-certifier-container.jsx
+++ b/src/renderer/certifiers/become-certifier-container.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { push } from 'connected-react-router';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import BecomeCertifierPage from './become-certifier-page';
 
 const styles = theme => ({});

--- a/src/renderer/certifiers/become-certifier-page.jsx
+++ b/src/renderer/certifiers/become-certifier-page.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Button, Divider, withStyles, IconButton } from '@material-ui/core';
+import { Typography, Button, Divider, IconButton } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CloseButtonIcon, KeyTooltip, TooltipArrow, InfoTooltip } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/certifiers/common/documents-list-container.jsx
+++ b/src/renderer/certifiers/common/documents-list-container.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
-import { Typography, withStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	FileImageIcon,
 	FileDefaultIcon,

--- a/src/renderer/certifiers/common/documents-list-page.jsx
+++ b/src/renderer/certifiers/common/documents-list-page.jsx
@@ -1,13 +1,6 @@
 import React from 'react';
-import {
-	Table,
-	TableBody,
-	TableRow,
-	TableCell,
-	TableHead,
-	Typography,
-	withStyles
-} from '@material-ui/core';
+import { Table, TableBody, TableRow, TableCell, TableHead, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableHeadRow, ViewIcon, RefreshIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/certifiers/common/notarization-process-container.jsx
+++ b/src/renderer/certifiers/common/notarization-process-container.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import NotarizationProcess from './notarization-process-popup';
 
 const styles = theme => ({});

--- a/src/renderer/certifiers/common/notarization-process-popup.jsx
+++ b/src/renderer/certifiers/common/notarization-process-popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Button, withStyles, Divider, List, ListItem } from '@material-ui/core';
+import { Typography, Button, Divider, List, ListItem } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { ExchangeIcon, baseDark, grey, OkayIcon } from 'selfkey-ui';
 import { Popup } from '../../common';
 

--- a/src/renderer/certifiers/common/require-payment-container.jsx
+++ b/src/renderer/certifiers/common/require-payment-container.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import RequirePayment from './require-payment-popup';
 
 const styles = theme => ({});

--- a/src/renderer/certifiers/common/require-payment-popup.jsx
+++ b/src/renderer/certifiers/common/require-payment-popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Button, withStyles, Divider, Input } from '@material-ui/core';
+import { Typography, Button, Divider, Input } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { PaymentIcon, Copy, baseDark, grey } from 'selfkey-ui';
 import { Popup } from '../../common';
 

--- a/src/renderer/certifiers/dashboard/_dashboard-messages.jsx
+++ b/src/renderer/certifiers/dashboard/_dashboard-messages.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
 import {
-	withStyles,
 	Typography,
 	Paper,
 	Divider,
@@ -12,6 +11,7 @@ import {
 	TableRow,
 	TablePagination
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableHeadRow, ViewIcon, RefreshIcon, ReplyIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/certifiers/dashboard/dashboard-analytics-container.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-analytics-container.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import CertifiersDashboardAnalyticsPage from './dashboard-analytics-page';
 
 const styles = theme => ({});

--- a/src/renderer/certifiers/dashboard/dashboard-analytics-page.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-analytics-page.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({});
 

--- a/src/renderer/certifiers/dashboard/dashboard-container.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-container.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { Typography, withStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import DashboardPageTabs from './dashboard-tabs';
 
 const styles = theme => ({

--- a/src/renderer/certifiers/dashboard/dashboard-history-container.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-history-container.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import CertifiersDashboardHistoryPage from './dashboard-history-page';
 
 const styles = theme => ({});

--- a/src/renderer/certifiers/dashboard/dashboard-history-page.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-history-page.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 import {
-	withStyles,
 	Typography,
 	Paper,
 	Divider,
@@ -12,6 +11,7 @@ import {
 	TableRow,
 	TablePagination
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableHeadRow, ViewIcon, RefreshIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/certifiers/dashboard/dashboard-overview-container.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-overview-container.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import CertifiersDashboardOverviewPage from './dashboard-overview-page';
 
 const styles = theme => ({});

--- a/src/renderer/certifiers/dashboard/dashboard-overview-page.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-overview-page.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 import {
-	withStyles,
 	Typography,
 	Paper,
 	Divider,
@@ -11,6 +10,7 @@ import {
 	TableCell,
 	TableRow
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableHeadRow, ViewIcon, RefreshIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/certifiers/dashboard/dashboard-tabs.jsx
+++ b/src/renderer/certifiers/dashboard/dashboard-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { Tabs, Tab } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CertifiersDashboardOverviewTab } from './dashboard-overview-container';
 import { CertifiersDashboardAnalyticsTab } from './dashboard-analytics-container';
 import { CertifiersDashboardHistoryTab } from './dashboard-history-container';

--- a/src/renderer/certifiers/individual-request-container.jsx
+++ b/src/renderer/certifiers/individual-request-container.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { identitySelectors } from 'common/identity';

--- a/src/renderer/certifiers/individual-request-page.jsx
+++ b/src/renderer/certifiers/individual-request-page.jsx
@@ -6,14 +6,13 @@ import {
 	Card,
 	CardContent,
 	CardHeader,
-	withStyles,
 	Divider,
 	List,
 	ListItem,
-	createStyles,
 	Button,
 	Grid
 } from '@material-ui/core';
+import { createStyles, withStyles } from '@material-ui/styles';
 import {
 	success,
 	warning,

--- a/src/renderer/common/accordion.jsx
+++ b/src/renderer/common/accordion.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-	withStyles,
 	Typography,
 	ExpansionPanel,
 	ExpansionPanelSummary,
@@ -13,9 +12,11 @@ import {
 	List,
 	ListItem
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { typography } from 'selfkey-ui';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import { Alert } from './alert';
+
 const styles = theme => ({
 	tabContent: {
 		marginTop: '15px',

--- a/src/renderer/common/address-shortener.js
+++ b/src/renderer/common/address-shortener.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	addressContainer: {

--- a/src/renderer/common/alert.js
+++ b/src/renderer/common/alert.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import classNames from 'classnames';
 import { CheckOutlined } from '@material-ui/icons';
 import { primary, success, secondary, warning, error, AttributeAlertIcon } from 'selfkey-ui';

--- a/src/renderer/common/attributes-table.jsx
+++ b/src/renderer/common/attributes-table.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, CardHeader, CardContent, List, Divider, Card } from '@material-ui/core';
+import { Grid, CardHeader, CardContent, List, Divider, Card } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 import { typography } from 'selfkey-ui';
 

--- a/src/renderer/common/header-icon.jsx
+++ b/src/renderer/common/header-icon.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CheckMaIcon, DeniedIcon, HourGlassIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/common/input-title.js
+++ b/src/renderer/common/input-title.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	optional: {

--- a/src/renderer/common/popup.jsx
+++ b/src/renderer/common/popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Modal, Typography, withStyles, Grid, Paper } from '@material-ui/core';
+import { Modal, Typography, Grid, Paper } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	ModalWrap,
 	ModalCloseButton,

--- a/src/renderer/common/token-price.js
+++ b/src/renderer/common/token-price.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { getLocale } from 'common/locale/selectors';
 import { PriceSummary } from 'selfkey-ui';
 import { getFiatCurrency } from 'common/fiatCurrency/selectors';

--- a/src/renderer/common/transaction-error-popup.jsx
+++ b/src/renderer/common/transaction-error-popup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Popup } from './popup';
-import { Grid, Typography, withStyles } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { WarningShieldIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/common/transaction-processing-popup.jsx
+++ b/src/renderer/common/transaction-processing-popup.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Popup } from './popup';
-import { Grid, Typography, withStyles } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { HourGlassLargeIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/corporate/common/corporate-applications.jsx
+++ b/src/renderer/corporate/common/corporate-applications.jsx
@@ -6,9 +6,9 @@ import {
 	Typography,
 	Table,
 	TableHead,
-	TableBody,
-	withStyles
+	TableBody
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	HourGlassSmallIcon,
 	CheckMaIcon,

--- a/src/renderer/corporate/common/corporate-cap-table.jsx
+++ b/src/renderer/corporate/common/corporate-cap-table.jsx
@@ -6,9 +6,9 @@ import {
 	Typography,
 	Table,
 	TableHead,
-	TableBody,
-	withStyles
+	TableBody
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableRow, SmallTableCell, EditTransparentIcon, SmallTableHeadRow } from 'selfkey-ui';
 import {
 	getEntityType,

--- a/src/renderer/corporate/common/corporate-details.jsx
+++ b/src/renderer/corporate/common/corporate-details.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { CardHeader, Card, CardContent, Typography, withStyles, Grid } from '@material-ui/core';
+import { CardHeader, Card, CardContent, Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CheckMaIcon, AttributeAlertIcon, EditTransparentIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/corporate/common/corporate-documents.jsx
+++ b/src/renderer/corporate/common/corporate-documents.jsx
@@ -11,9 +11,9 @@ import {
 	TableHead,
 	TableBody,
 	IconButton,
-	Button,
-	withStyles
+	Button
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	SmallTableHeadRow,
 	EditTransparentIcon,

--- a/src/renderer/corporate/common/corporate-information.jsx
+++ b/src/renderer/corporate/common/corporate-information.jsx
@@ -10,9 +10,9 @@ import {
 	TableHead,
 	TableBody,
 	IconButton,
-	Button,
-	withStyles
+	Button
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	BookIcon,
 	SmallTableHeadRow,

--- a/src/renderer/corporate/common/corporate-members.jsx
+++ b/src/renderer/corporate/common/corporate-members.jsx
@@ -11,9 +11,9 @@ import {
 	TableHead,
 	TableBody,
 	IconButton,
-	Button,
-	withStyles
+	Button
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableHeadRow, EditTransparentIcon, DeleteIcon, DropdownIcon } from 'selfkey-ui';
 import CorporateDocuments from './corporate-documents';
 import CorporateInformation from './corporate-information';

--- a/src/renderer/corporate/common/corporate-org-chart.jsx
+++ b/src/renderer/corporate/common/corporate-org-chart.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, CardHeader, Card, CardContent, withStyles } from '@material-ui/core';
+import { Grid, CardHeader, Card, CardContent } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { grey, EditTransparentIcon, typography } from 'selfkey-ui';
 import 'react-orgchart/index.css';
 import OrgChart from 'react-orgchart';

--- a/src/renderer/corporate/common/corporate-shareholding.jsx
+++ b/src/renderer/corporate/common/corporate-shareholding.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, CardHeader, Card, CardContent, withStyles } from '@material-ui/core';
+import { Grid, CardHeader, Card, CardContent } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Chart } from 'react-google-charts';
 import { getProfileName, getMemberEquity } from './common-helpers.jsx';
 

--- a/src/renderer/corporate/dashboard/applications-tab.jsx
+++ b/src/renderer/corporate/dashboard/applications-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({});
 

--- a/src/renderer/corporate/dashboard/dashboard-page.jsx
+++ b/src/renderer/corporate/dashboard/dashboard-page.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Grid, withStyles } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CorporateComponent } from '../common/corporate-component';
 import { CorporateDashboardTabs } from './dashboard-tabs';
 

--- a/src/renderer/corporate/dashboard/dashboard-tabs.jsx
+++ b/src/renderer/corporate/dashboard/dashboard-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { Tabs, Tab } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CorporateOverviewTab } from './overview-tab';
 import { CorporateInformationTab } from './information-tab';
 import { CorporateMembersTab } from './members-tab';

--- a/src/renderer/corporate/dashboard/history-tab.jsx
+++ b/src/renderer/corporate/dashboard/history-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({});
 

--- a/src/renderer/corporate/dashboard/information-tab.jsx
+++ b/src/renderer/corporate/dashboard/information-tab.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CorporateInformation } from '../common/corporate-information';
 import { CorporateDocuments } from '../common/corporate-documents';
 

--- a/src/renderer/corporate/dashboard/members-tab.jsx
+++ b/src/renderer/corporate/dashboard/members-tab.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CorporateMembers } from '../common/corporate-members';
 
 const styles = theme => ({});

--- a/src/renderer/corporate/dashboard/overview-tab.jsx
+++ b/src/renderer/corporate/dashboard/overview-tab.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, withStyles } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CorporateDetails } from '../common/corporate-details';
 import { CorporateApplicationsSummary } from '../common/corporate-applications';
 import { CorporateCapTable } from '../common/corporate-cap-table';

--- a/src/renderer/corporate/member/corporate-member-container.jsx
+++ b/src/renderer/corporate/member/corporate-member-container.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import _ from 'lodash';
 import { CorporateMemberForm } from './corporate-member-form';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { push } from 'connected-react-router';
 import { appSelectors } from 'common/app';
 import { identityAttributes } from 'common/identity/utils';

--- a/src/renderer/corporate/member/corporate-member-form.jsx
+++ b/src/renderer/corporate/member/corporate-member-form.jsx
@@ -8,7 +8,7 @@ import {
 	StyledButton
 } from 'selfkey-ui';
 import { Grid, Modal, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { CorporateMemberIndividualForm } from './member-individual-form';
 import { CorporateMemberCorporateForm } from './member-corporate-form';
 import { CorporateMemberSharesForm } from './member-shares-form';

--- a/src/renderer/corporate/member/member-corporate-form.jsx
+++ b/src/renderer/corporate/member/member-corporate-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography, Input, Select, MenuItem } from '@material-ui/core';
 import { KeyboardArrowDown } from '@material-ui/icons';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { KeyPicker } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/corporate/member/member-individual-form.jsx
+++ b/src/renderer/corporate/member/member-individual-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography, Input, Select, MenuItem } from '@material-ui/core';
 import { KeyboardArrowDown } from '@material-ui/icons';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	regularText: {

--- a/src/renderer/corporate/member/member-select-role.jsx
+++ b/src/renderer/corporate/member/member-select-role.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import {
 	DirectorIcon,
 	ObserverIcon,

--- a/src/renderer/corporate/member/member-select-type.jsx
+++ b/src/renderer/corporate/member/member-select-type.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { ProfileIcon, CompanyIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/corporate/member/member-shares-form.jsx
+++ b/src/renderer/corporate/member/member-shares-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography, Input, Select, MenuItem } from '@material-ui/core';
 import { KeyboardArrowDown } from '@material-ui/icons';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	regularText: {

--- a/src/renderer/corporate/wizard/corporate-wizard.jsx
+++ b/src/renderer/corporate/wizard/corporate-wizard.jsx
@@ -7,9 +7,9 @@ import {
 	Button,
 	Input,
 	MenuItem,
-	Select,
-	withStyles
+	Select
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { KeyboardArrowDown } from '@material-ui/icons';
 import { KeyPicker } from 'selfkey-ui';
 

--- a/src/renderer/crypto-manager/add-token-container.jsx
+++ b/src/renderer/crypto-manager/add-token-container.jsx
@@ -5,15 +5,8 @@ import { addressBookSelectors, addressBookOperations } from 'common/address-book
 import { getTokens } from 'common/wallet-tokens/selectors';
 import { walletTokensOperations } from 'common/wallet-tokens';
 import history from 'common/store/history';
-import {
-	Grid,
-	Button,
-	Typography,
-	withStyles,
-	Input,
-	IconButton,
-	CircularProgress
-} from '@material-ui/core';
+import { Grid, Button, Typography, Input, IconButton, CircularProgress } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	MyCryptoLargeIcon,
 	ModalWrap,

--- a/src/renderer/crypto-manager/crypto-manager-container.jsx
+++ b/src/renderer/crypto-manager/crypto-manager-container.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Grid, Button, Typography, withStyles, List } from '@material-ui/core';
+import { Grid, Button, Typography, List } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import CryptoPriceTableContainer from './crypto-price-table-container';
 import { push } from 'connected-react-router';

--- a/src/renderer/crypto-manager/crypto-price-table.jsx
+++ b/src/renderer/crypto-manager/crypto-price-table.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import {
-	withStyles,
 	Table,
 	TableBody,
 	TableHead,
@@ -10,6 +9,7 @@ import {
 	Grid,
 	Button
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { PriceSummary, DeleteIcon, SmallTableHeadRow } from 'selfkey-ui';
 import { Popup } from '../common/popup';
 

--- a/src/renderer/dashboard/buy-key-popup-modal.jsx
+++ b/src/renderer/dashboard/buy-key-popup-modal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, List, ListItem, withStyles, Typography, Divider } from '@material-ui/core';
+import { Grid, List, ListItem, Typography, Divider } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { PaymentIcon, Copy } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/dashboard/buy-key-widget.jsx
+++ b/src/renderer/dashboard/buy-key-widget.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { featureIsEnabled } from 'common/feature-flags';
 import { Grid, Typography, Button } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { CustomIcon, CoinsIcon, ExchangeSmallIcon } from 'selfkey-ui';
 import BuyKeyPopup from './buy-key-popup-container';
 import TokenSwap from '../transaction/swap';

--- a/src/renderer/dashboard/crypto-chart-box.jsx
+++ b/src/renderer/dashboard/crypto-chart-box.jsx
@@ -9,7 +9,7 @@ import { getViewAll } from 'common/view-all-tokens/selectors';
 import { getFiatCurrency } from 'common/fiatCurrency/selectors';
 import { getVisibleTokens, getTopTokenListSize } from 'common/wallet-tokens/selectors';
 import { viewAllOperations } from 'common/view-all-tokens';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
 
 const styles = () => ({

--- a/src/renderer/dashboard/dashboard-marketplace-applications.jsx
+++ b/src/renderer/dashboard/dashboard-marketplace-applications.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { Grid, Typography, Button } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { push } from 'connected-react-router';
 import {
 	MarketplaceIcon,

--- a/src/renderer/dashboard/dashboard-selfkey-profile.jsx
+++ b/src/renderer/dashboard/dashboard-selfkey-profile.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { Grid, Typography, Button, List, ListItem } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { identityOperations } from 'common/identity';
 import { IdCardIcon, AttributeAlertIcon, CheckMaIcon, HourGlassIcon } from 'selfkey-ui';
 import { identitySelectors } from '../../common/identity';

--- a/src/renderer/dashboard/index.jsx
+++ b/src/renderer/dashboard/index.jsx
@@ -8,7 +8,7 @@ import DashboardMarketplaceApplications from './dashboard-marketplace-applicatio
 import DashboardSelfkeyProfile from './dashboard-selfkey-profile';
 import TransactionsHistory from '../transaction/transactions-history';
 import { Alert } from '../common';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { appSelectors } from 'common/app';
 
 const styles = theme => ({

--- a/src/renderer/dashboard/token-box.jsx
+++ b/src/renderer/dashboard/token-box.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { getWallet } from 'common/wallet/selectors';
 import { Copy, TransferIcon } from 'selfkey-ui';
 import { Grid, Paper, IconButton, Typography, Divider } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { AddressShortener } from '../common/address-shortener';
 
 const styles = theme => ({

--- a/src/renderer/deposit/deposit-manager.js
+++ b/src/renderer/deposit/deposit-manager.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { withStyles, Button } from '@material-ui/core';
+import { Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { UnlockIcon, ReturnIcon, HourGlassSmallIcon, CalendarIcon } from 'selfkey-ui';
 import { marketplacesSelectors, marketplacesOperations } from 'common/marketplaces';

--- a/src/renderer/deposit/transactions/deposit-content.jsx
+++ b/src/renderer/deposit/transactions/deposit-content.jsx
@@ -6,10 +6,10 @@ import {
 	FormControlLabel,
 	FormControl,
 	FormHelperText,
-	withStyles,
 	Button,
 	Typography
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 import { TransactionFeeSelector, ExchangeLargeIcon } from 'selfkey-ui';
 

--- a/src/renderer/deposit/transactions/return-deposit-content.jsx
+++ b/src/renderer/deposit/transactions/return-deposit-content.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
-
-import { Button, Grid, withStyles, Typography } from '@material-ui/core';
+import { Button, Grid, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { ReturnLargeIcon, TransactionFeeSelector } from 'selfkey-ui';
 import config from 'common/config';
 

--- a/src/renderer/deposit/transactions/without-balance-popup.jsx
+++ b/src/renderer/deposit/transactions/without-balance-popup.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { getExchangeLinks } from 'common/exchanges/selectors';
-import { Grid, List, ListItem, withStyles, Typography } from '@material-ui/core';
+import { Grid, List, ListItem, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { WarningShieldIcon } from 'selfkey-ui';
 import { Popup } from '../../common/popup';
 

--- a/src/renderer/did/associate-did.jsx
+++ b/src/renderer/did/associate-did.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, Button, Typography, withStyles, Input, CircularProgress } from '@material-ui/core';
+import { Grid, Button, Typography, Input, CircularProgress } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { MergeIcon } from 'selfkey-ui';
 import { Popup } from '../common';
 

--- a/src/renderer/did/create-did-popup.jsx
+++ b/src/renderer/did/create-did-popup.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Grid, withStyles, Typography, Button, IconButton, Divider } from '@material-ui/core';
+import { Grid, Typography, Button, IconButton, Divider } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../common/popup';
 import { KeyTooltip, TooltipArrow, PaymentIcon, InfoTooltip } from 'selfkey-ui';
 

--- a/src/renderer/did/display-did.jsx
+++ b/src/renderer/did/display-did.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DIDIcon } from 'selfkey-ui';
-import { Grid, withStyles, Typography, Card, CardHeader, CardContent } from '@material-ui/core';
+import { Grid, Typography, Card, CardHeader, CardContent } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	hr: {

--- a/src/renderer/did/register-did-card.jsx
+++ b/src/renderer/did/register-did-card.jsx
@@ -1,13 +1,6 @@
 import React, { PureComponent } from 'react';
-import {
-	CardContent,
-	Card,
-	CardHeader,
-	Grid,
-	Typography,
-	Button,
-	withStyles
-} from '@material-ui/core';
+import { CardContent, Card, CardHeader, Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { DIDIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/global-error.jsx
+++ b/src/renderer/global-error.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, withStyles, Typography } from '@material-ui/core';
+import { Button, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from './common';
 import { error } from 'selfkey-ui';
 

--- a/src/renderer/home/index.jsx
+++ b/src/renderer/home/index.jsx
@@ -3,7 +3,7 @@ import { Grid, Typography, Paper, Button } from '@material-ui/core';
 import { primary, HelpIcon, QuitIcon, SelfkeyLogoTemp } from 'selfkey-ui';
 import { tokensOperations } from 'common/tokens';
 import backgroundImage from '../../../static/assets/images/bgs/background.jpg';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { appOperations, appSelectors } from 'common/app';

--- a/src/renderer/home/loading.jsx
+++ b/src/renderer/home/loading.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Paper, CircularProgress } from '@material-ui/core';
-
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { appOperations } from 'common/app';
 import backgroundImage from '../../../static/assets/images/bgs/background.jpg';

--- a/src/renderer/individual/common/attributes-table.jsx
+++ b/src/renderer/individual/common/attributes-table.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import { Table, TableBody, IconButton, TableHead, Typography, withStyles } from '@material-ui/core';
+import { Table, TableBody, IconButton, TableHead, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	EditTransparentIcon,
 	DeleteIcon,

--- a/src/renderer/individual/common/documents-table.jsx
+++ b/src/renderer/individual/common/documents-table.jsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import {
-	Table,
-	TableBody,
-	TableRow,
-	IconButton,
-	TableHead,
-	Typography,
-	withStyles
-} from '@material-ui/core';
+import { Table, TableBody, TableRow, IconButton, TableHead, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	FilePdfIcon,
 	FileImageIcon,

--- a/src/renderer/individual/common/hexagon-avatar.jsx
+++ b/src/renderer/individual/common/hexagon-avatar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import avatarPlaceholder from '../../../../static/assets/images/icons/icon-add-image.svg';
 
 const styles = theme => ({

--- a/src/renderer/individual/common/notify-popup.jsx
+++ b/src/renderer/individual/common/notify-popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, Typography, Button } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Popup } from '../../common/popup';
 
 const styles = theme => ({});

--- a/src/renderer/individual/dashboard/applications-tab.jsx
+++ b/src/renderer/individual/dashboard/applications-tab.jsx
@@ -12,10 +12,9 @@ import {
 	Divider,
 	ExpansionPanelDetails,
 	List,
-	ListItem,
-	createStyles,
-	withStyles
+	ListItem
 } from '@material-ui/core';
+import { createStyles, withStyles } from '@material-ui/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import {

--- a/src/renderer/individual/dashboard/dashboard-page.jsx
+++ b/src/renderer/individual/dashboard/dashboard-page.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Grid, withStyles } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { IndividualDashboardTabs } from './dashboard-tabs';
 
 const styles = theme => ({

--- a/src/renderer/individual/dashboard/dashboard-tabs.jsx
+++ b/src/renderer/individual/dashboard/dashboard-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { Tabs, Tab } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { IndividualOverviewTab } from './overview-tab';
 import { IndividualApplicationsTab } from './applications-tab';
 

--- a/src/renderer/individual/dashboard/overview-tab.jsx
+++ b/src/renderer/individual/dashboard/overview-tab.jsx
@@ -1,13 +1,6 @@
 import React from 'react';
-import {
-	Grid,
-	CardHeader,
-	Card,
-	CardContent,
-	Typography,
-	Button,
-	withStyles
-} from '@material-ui/core';
+import { Grid, CardHeader, Card, CardContent, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { BookIcon, IdCardIcon } from 'selfkey-ui';
 import { HexagonAvatar } from '../common/hexagon-avatar';
 import backgroundImage from '../../../../static/assets/images/icons/icon-marketplace.png';

--- a/src/renderer/kyc/application/application-progress-container.jsx
+++ b/src/renderer/kyc/application/application-progress-container.jsx
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import { kycOperations } from 'common/kyc';
 import { push } from 'connected-react-router';
 import { CloseButtonIcon, HourGlassLargeIcon } from 'selfkey-ui';
-import { Grid, Typography, Button, withStyles } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	container: {

--- a/src/renderer/kyc/application/application-status.jsx
+++ b/src/renderer/kyc/application/application-status.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, Typography, Button } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { success, warning, AttributeAlertIcon } from 'selfkey-ui';
 import { CheckOutlined } from '@material-ui/icons';
 

--- a/src/renderer/kyc/application/current-application-popup.jsx
+++ b/src/renderer/kyc/application/current-application-popup.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-	withStyles,
 	Typography,
 	CircularProgress,
 	FormControlLabel,
@@ -17,7 +16,7 @@ import {
 	RadioGroup,
 	TableCell
 } from '@material-ui/core';
-
+import { withStyles } from '@material-ui/styles';
 import {
 	SmallTableHeadRow,
 	SmallTableCell,

--- a/src/renderer/kyc/kyc-manager.jsx
+++ b/src/renderer/kyc/kyc-manager.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { ListItem, List, withStyles } from '@material-ui/core';
+import { ListItem, List } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { KycRequirements } from './requirements/container';
 import { kycSelectors, kycOperations } from '../../common/kyc';
 

--- a/src/renderer/kyc/requirements/requirements-list.jsx
+++ b/src/renderer/kyc/requirements/requirements-list.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, List, ListItem, CircularProgress } from '@material-ui/core';
 import { CheckedIcon, StepIcon } from 'selfkey-ui';
 

--- a/src/renderer/marketplace/authentication/error.jsx
+++ b/src/renderer/marketplace/authentication/error.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../common/popup';
 import { HourGlassLargeIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/authentication/hardware-wallet/declined.jsx
+++ b/src/renderer/marketplace/authentication/hardware-wallet/declined.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../../common/popup';
 import { WarningShieldIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/authentication/hardware-wallet/error.jsx
+++ b/src/renderer/marketplace/authentication/hardware-wallet/error.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../../common/popup';
 import { HourGlassLargeIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/authentication/hardware-wallet/timeout.jsx
+++ b/src/renderer/marketplace/authentication/hardware-wallet/timeout.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../../common/popup';
 import { HourGlassLargeIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/authentication/hardware-wallet/timer.jsx
+++ b/src/renderer/marketplace/authentication/hardware-wallet/timer.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Grid, withStyles } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../../common/popup';
 import { kycSelectors } from 'common/kyc';

--- a/src/renderer/marketplace/authentication/hardware-wallet/unlock.jsx
+++ b/src/renderer/marketplace/authentication/hardware-wallet/unlock.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../../common/popup';
 import { UnlockLargeIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/bank-accounts/checkout/checkout-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/checkout/checkout-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { BigNumber } from 'bignumber.js';
 import config from 'common/config';
 import EthUnits from 'common/utils/eth-units';

--- a/src/renderer/marketplace/bank-accounts/checkout/payment-complete-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/checkout/payment-complete-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { marketplaceSelectors } from 'common/marketplace';

--- a/src/renderer/marketplace/bank-accounts/checkout/payment-complete.jsx
+++ b/src/renderer/marketplace/bank-accounts/checkout/payment-complete.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { HourGlassLargeIcon } from 'selfkey-ui';
 import { Popup } from '../../../common';

--- a/src/renderer/marketplace/bank-accounts/checkout/payment-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/checkout/payment-container.jsx
@@ -1,7 +1,7 @@
 import BN from 'bignumber.js';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { featureIsEnabled } from 'common/feature-flags';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors } from 'common/kyc';

--- a/src/renderer/marketplace/bank-accounts/common/account-option.jsx
+++ b/src/renderer/marketplace/bank-accounts/common/account-option.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-	withStyles,
 	Grid,
 	Typography,
 	Divider,
@@ -9,6 +8,7 @@ import {
 	ExpansionPanelSummary,
 	Radio
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { AttributesTable, Alert } from '../../../common';
 import { typography } from 'selfkey-ui';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';

--- a/src/renderer/marketplace/bank-accounts/common/option-selection.jsx
+++ b/src/renderer/marketplace/bank-accounts/common/option-selection.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { CloseButtonIcon } from 'selfkey-ui';
 import { FlagCountryName } from '../../common';

--- a/src/renderer/marketplace/bank-accounts/details/details-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-container.jsx
@@ -6,7 +6,7 @@ import { MarketplaceBankAccountsComponent } from '../common/marketplace-bank-acc
 import { pricesSelectors } from 'common/prices';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { identitySelectors } from 'common/identity';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { BankingDetailsPage } from './details-page';
 import { marketplaceSelectors } from 'common/marketplace';
 

--- a/src/renderer/marketplace/bank-accounts/details/details-country-tab.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-country-tab.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { withStyles, Typography, Grid, List, ListItem } from '@material-ui/core';
+import { Typography, Grid, List, ListItem } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { PageLoading, sanitize } from '../../common';
 import 'flag-icon-css/css/flag-icon.css';
 

--- a/src/renderer/marketplace/bank-accounts/details/details-description-tab.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-description-tab.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { withStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../../common';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/bank-accounts/details/details-page.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-page.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Button, Typography } from '@material-ui/core';
 import { ApplicationStatusBar } from '../../../kyc/application/application-status';
 import { MoneyIcon, BackButton } from 'selfkey-ui';

--- a/src/renderer/marketplace/bank-accounts/details/details-services-tab.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-services-tab.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../../common';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/bank-accounts/details/details-tabs.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { Tabs, Tab } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { BankingTypesTab } from './details-types-tab';
 import { BankingCountryTab } from './details-country-tab';
 import { BankingDescriptionTab } from './details-description-tab';

--- a/src/renderer/marketplace/bank-accounts/details/details-types-tab.jsx
+++ b/src/renderer/marketplace/bank-accounts/details/details-types-tab.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { withStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { BankingAccountOption } from '../common/account-option';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/bank-accounts/list/account-type-tabs.jsx
+++ b/src/renderer/marketplace/bank-accounts/list/account-type-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab, Typography } from '@material-ui/core';
+import { Tabs, Tab, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	tabContent: {

--- a/src/renderer/marketplace/bank-accounts/list/offers-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/list/offers-container.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { pricesSelectors } from 'common/prices';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { BankingOffersPage } from './offers-page';
 import { marketplaceSelectors } from 'common/marketplace';
 import { MarketplaceBankAccountsComponent } from '../common/marketplace-bank-accounts-component';

--- a/src/renderer/marketplace/bank-accounts/list/offers-page.jsx
+++ b/src/renderer/marketplace/bank-accounts/list/offers-page.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { BankingOffersTable } from './offers-table';
 import { BankingAccountTypeTabs } from './account-type-tabs';
 import { PageLoading } from '../../common';
-import { Button, Typography, Grid, withStyles } from '@material-ui/core';
+import { Button, Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { BankIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/bank-accounts/list/offers-table.jsx
+++ b/src/renderer/marketplace/bank-accounts/list/offers-table.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Typography, IconButton, Grid } from '@material-ui/core';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';

--- a/src/renderer/marketplace/bank-accounts/process-started/process-started-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/process-started/process-started-container.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Typography, Divider } from '@material-ui/core';
 import { marketplaceSelectors } from 'common/marketplace';
 import { MarketplaceProcessStarted } from '../../common/marketplace-process-started';

--- a/src/renderer/marketplace/bank-accounts/select-bank/select-bank-container.jsx
+++ b/src/renderer/marketplace/bank-accounts/select-bank/select-bank-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { marketplaceSelectors } from 'common/marketplace';

--- a/src/renderer/marketplace/categories/categories-list.jsx
+++ b/src/renderer/marketplace/categories/categories-list.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, withStyles, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { MarketplaceIcon } from 'selfkey-ui';
 import { MarketplaceCategory } from './category';
 

--- a/src/renderer/marketplace/categories/category.jsx
+++ b/src/renderer/marketplace/categories/category.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { Grid, Button, withStyles, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Grid, Button, Typography } from '@material-ui/core';
 
 const styles = theme => ({
 	root: {

--- a/src/renderer/marketplace/common/flag-country-name.jsx
+++ b/src/renderer/marketplace/common/flag-country-name.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import 'flag-icon-css/css/flag-icon.css';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/common/marketplace-how-service-works.jsx
+++ b/src/renderer/marketplace/common/marketplace-how-service-works.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography, Grid } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	howItWorksBox: {

--- a/src/renderer/marketplace/common/marketplace-process-started.jsx
+++ b/src/renderer/marketplace/common/marketplace-process-started.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { HourGlassLargeIcon } from 'selfkey-ui';
 import { Popup } from '../../common';

--- a/src/renderer/marketplace/common/marketplace-what-you-get.jsx
+++ b/src/renderer/marketplace/common/marketplace-what-you-get.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography, Grid } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../common';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/common/page-loading.jsx
+++ b/src/renderer/marketplace/common/page-loading.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { Grid, CircularProgress, withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Grid, CircularProgress } from '@material-ui/core';
 
 const styles = theme => ({
 	loading: {

--- a/src/renderer/marketplace/common/payment-checkout.jsx
+++ b/src/renderer/marketplace/common/payment-checkout.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { FlagCountryName } from '.';
 import { WhatYouGet } from './marketplace-what-you-get';

--- a/src/renderer/marketplace/common/payment-preapprove.jsx
+++ b/src/renderer/marketplace/common/payment-preapprove.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { withStyles, Grid, Typography, Button, IconButton } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Grid, Typography, Button, IconButton } from '@material-ui/core';
 import { Popup } from '../../common';
 import { PaymentIcon, KeyTooltip, InfoTooltip } from 'selfkey-ui';
 

--- a/src/renderer/marketplace/common/program-price.jsx
+++ b/src/renderer/marketplace/common/program-price.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	key: {

--- a/src/renderer/marketplace/common/resume-box.jsx
+++ b/src/renderer/marketplace/common/resume-box.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Typography, Grid } from '@material-ui/core';
 import classNames from 'classnames';
 import { primary } from 'selfkey-ui';
 const styles = theme => ({

--- a/src/renderer/marketplace/common/tax-treaties-map.jsx
+++ b/src/renderer/marketplace/common/tax-treaties-map.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	mapContainer: {

--- a/src/renderer/marketplace/common/tax-treaties-table.jsx
+++ b/src/renderer/marketplace/common/tax-treaties-table.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography } from '@material-ui/core';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';

--- a/src/renderer/marketplace/common/what-you-get-tab.jsx
+++ b/src/renderer/marketplace/common/what-you-get-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { WhatYouGet } from './marketplace-what-you-get';
 import { HowServiceWorks } from './marketplace-how-service-works';
 

--- a/src/renderer/marketplace/corporate-preview-container.jsx
+++ b/src/renderer/marketplace/corporate-preview-container.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, withStyles, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { MarketplaceIcon, HourGlassLargeIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/exchanges/exchanges-details-container.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-details-container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { marketplacesSelectors } from 'common/marketplaces';
 import { marketplaceSelectors } from 'common/marketplace';
 import { kycSelectors, kycOperations } from 'common/kyc';

--- a/src/renderer/marketplace/exchanges/exchanges-details.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-details.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { UserPlusIcon, primary, CalendarDepositIcon, typography } from 'selfkey-ui';
 import { MarketplaceDisclaimer } from '../common/disclaimer';
 import { Grid, Divider, FormGroup, FormControl, Button, Typography } from '@material-ui/core';

--- a/src/renderer/marketplace/exchanges/exchanges-list-container.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-list-container.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { marketplaceSelectors } from 'common/marketplace';

--- a/src/renderer/marketplace/exchanges/exchanges-list-item.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-list-item.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, TableRow, TableCell, Typography, Grid, withStyles } from '@material-ui/core';
+import { Button, TableRow, TableCell, Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Tag } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/exchanges/exchanges-list.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-list.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
 	Grid,
-	withStyles,
 	Typography,
 	Divider,
 	Table,
@@ -9,6 +8,7 @@ import {
 	TableBody,
 	TableCell
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { LargeTableHeadRow, BackButton } from 'selfkey-ui';
 import { ExchangesListItem } from './exchanges-list-item';
 import { MarketplaceDisclaimer } from '../common/disclaimer';

--- a/src/renderer/marketplace/incorporation/checkout/incorporations-checkout-container.jsx
+++ b/src/renderer/marketplace/incorporation/checkout/incorporations-checkout-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { BigNumber } from 'bignumber.js';
 import config from 'common/config';
 import EthUnits from 'common/utils/eth-units';

--- a/src/renderer/marketplace/incorporation/checkout/incorporations-payment-complete-container.jsx
+++ b/src/renderer/marketplace/incorporation/checkout/incorporations-payment-complete-container.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { incorporationsSelectors } from 'common/incorporations';

--- a/src/renderer/marketplace/incorporation/checkout/incorporations-payment-container.jsx
+++ b/src/renderer/marketplace/incorporation/checkout/incorporations-payment-container.jsx
@@ -1,7 +1,7 @@
 import BN from 'bignumber.js';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { featureIsEnabled } from 'common/feature-flags';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors } from 'common/kyc';

--- a/src/renderer/marketplace/incorporation/common/country-info.jsx
+++ b/src/renderer/marketplace/incorporation/common/country-info.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, List, ListItem } from '@material-ui/core';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { incorporationsSelectors, incorporationsOperations } from 'common/incorporations';

--- a/src/renderer/marketplace/incorporation/common/incorporations-data-panel.jsx
+++ b/src/renderer/marketplace/incorporation/common/incorporations-data-panel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, List, ListItem, Typography } from '@material-ui/core';
+import { Grid, List, ListItem, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { GreenTick, DeniedTick } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/incorporation/common/kyc-requirements.jsx
+++ b/src/renderer/marketplace/incorporation/common/kyc-requirements.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, List, ListItem } from '@material-ui/core';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { CheckedIcon, StepIcon } from 'selfkey-ui';

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-container.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-container.jsx
@@ -6,7 +6,7 @@ import { MarketplaceIncorporationsComponent } from '../common/marketplace-incorp
 import { pricesSelectors } from 'common/prices';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { identitySelectors } from 'common/identity';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { marketplaceSelectors } from 'common/marketplace';
 import { IncorporationsDetailsPage } from './incorporations-details-page';
 

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-country-tab.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-country-tab.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Typography, Grid, List, ListItem } from '@material-ui/core';
+import { Typography, Grid, List, ListItem } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { PageLoading, sanitize } from '../../common';
 import 'flag-icon-css/css/flag-icon.css';
 

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-description-tab.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-description-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../../common';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-legal-tab.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-legal-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../../common';
 import { IncorporationsDataPanel } from '../common/incorporations-data-panel';
 

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-page.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-page.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Button, Typography } from '@material-ui/core';
 import { ApplicationStatusBar } from '../../../kyc/application/application-status';
 import { CertificateIcon, BackButton } from 'selfkey-ui';

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-services-tab.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-services-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../../common';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-tabs.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { Tabs, Tab } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { IncorporationsLegalTab } from './incorporations-details-legal-tab';
 import { IncorporationsTaxesTab } from './incorporations-details-taxes-tab';
 import { IncorporationsTaxTreatiesTab } from './incorporations-details-tax-treaties-tab';

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-tax-treaties-tab.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-tax-treaties-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { TaxTreatiesMap } from '../../common/tax-treaties-map';
 import { TaxTreatiesTable } from '../../common/tax-treaties-table';
 

--- a/src/renderer/marketplace/incorporation/details/incorporations-details-taxes-tab.jsx
+++ b/src/renderer/marketplace/incorporation/details/incorporations-details-taxes-tab.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { sanitize } from '../../common';
 import { IncorporationsDataPanel } from '../common/incorporations-data-panel';
 

--- a/src/renderer/marketplace/incorporation/list/incorporations-list-container.jsx
+++ b/src/renderer/marketplace/incorporation/list/incorporations-list-container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { pricesSelectors } from 'common/prices';

--- a/src/renderer/marketplace/incorporation/list/incorporations-list-page.jsx
+++ b/src/renderer/marketplace/incorporation/list/incorporations-list-page.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { IncorporationsListTable } from './incorporations-list-table';
 import { PageLoading } from '../../common';
-import { Button, Typography, Grid, withStyles } from '@material-ui/core';
+import { Button, Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { IncorporationsIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/incorporation/list/incorporations-list-table.jsx
+++ b/src/renderer/marketplace/incorporation/list/incorporations-list-table.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Typography, Grid } from '@material-ui/core';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';

--- a/src/renderer/marketplace/marketplace-loading-error-container.jsx
+++ b/src/renderer/marketplace/marketplace-loading-error-container.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, withStyles, Typography, Button } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { MarketplaceIcon, WarningShieldIcon } from 'selfkey-ui';
 import { connect } from 'react-redux';
 import { vendorOperations } from '../../common/marketplace/vendors';

--- a/src/renderer/marketplace/notarization/checkout/payment-complete-container.jsx
+++ b/src/renderer/marketplace/notarization/checkout/payment-complete-container.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors, kycOperations } from 'common/kyc';
 import { transactionSelectors } from 'common/transaction';

--- a/src/renderer/marketplace/notarization/checkout/payment-container.jsx
+++ b/src/renderer/marketplace/notarization/checkout/payment-container.jsx
@@ -1,6 +1,6 @@
 import BN from 'bignumber.js';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { featureIsEnabled } from 'common/feature-flags';
 import { getWallet } from 'common/wallet/selectors';
 import { kycSelectors } from 'common/kyc';

--- a/src/renderer/marketplace/notarization/common/message-container.jsx
+++ b/src/renderer/marketplace/notarization/common/message-container.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import NotarizationMessageWidget from './message-widget';
 
 const styles = theme => ({});

--- a/src/renderer/marketplace/notarization/common/message-widget.jsx
+++ b/src/renderer/marketplace/notarization/common/message-widget.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {
 	Typography,
 	Button,
-	withStyles,
 	Card,
 	CardHeader,
 	Divider,
 	CardContent,
 	Input
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { RoundCompany, RoundPerson, baseDark, grey } from 'selfkey-ui';
 import moment from 'moment';
 

--- a/src/renderer/marketplace/notarization/common/toc-container.jsx
+++ b/src/renderer/marketplace/notarization/common/toc-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import MarketplaceNotariesComponent from './marketplace-notaries-component';
 import TOCPopup from './toc-popup';
 

--- a/src/renderer/marketplace/notarization/common/toc-disagreement-container.jsx
+++ b/src/renderer/marketplace/notarization/common/toc-disagreement-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import MarketplaceNotariesComponent from './marketplace-notaries-component';
 import TOCDisagreementPopup from './toc-disagreement-popup';
 

--- a/src/renderer/marketplace/notarization/common/toc-disagreement-popup.jsx
+++ b/src/renderer/marketplace/notarization/common/toc-disagreement-popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Button, withStyles } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CloseButtonIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/notarization/common/toc-popup.jsx
+++ b/src/renderer/marketplace/notarization/common/toc-popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Button, withStyles } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { CloseButtonIcon } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/notarization/details/notarization-details-container.jsx
+++ b/src/renderer/marketplace/notarization/details/notarization-details-container.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { pricesSelectors } from 'common/prices';
 import { identitySelectors } from 'common/identity';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { marketplaceSelectors } from 'common/marketplace';
 import { MarketplaceNotariesComponent } from '../common/marketplace-notaries-component';
 import NotarizationDetailsPage from './notarization-details-page';

--- a/src/renderer/marketplace/notarization/details/notarization-details-key-tab.jsx
+++ b/src/renderer/marketplace/notarization/details/notarization-details-key-tab.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { withStyles, Typography, List, ListItem } from '@material-ui/core';
+import { Typography, List, ListItem } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	tabContainer: {

--- a/src/renderer/marketplace/notarization/details/notarization-details-page.jsx
+++ b/src/renderer/marketplace/notarization/details/notarization-details-page.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Button, withStyles } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { PageLoading, ProgramPrice } from '../../common';
 import { MarketplaceNotariesIcon, NotarizeDocumentIcon } from 'selfkey-ui';
 import { Alert } from '../../../common';

--- a/src/renderer/marketplace/notarization/details/notarization-details-tabs.jsx
+++ b/src/renderer/marketplace/notarization/details/notarization-details-tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Tabs, Tab } from '@material-ui/core';
+import { Tabs, Tab } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { NotarizationTypesTab } from './notarization-details-types-tab';
 import { NotarizationKeyTab } from './notarization-details-key-tab';
 

--- a/src/renderer/marketplace/notarization/details/notarization-details-types-tab.jsx
+++ b/src/renderer/marketplace/notarization/details/notarization-details-types-tab.jsx
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react';
 import {
-	withStyles,
 	Typography,
 	ExpansionPanel,
 	ExpansionPanelDetails,
 	ExpansionPanelSummary,
 	Divider
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import supportedDocumentTypes from './supported-document-types.json';
 

--- a/src/renderer/marketplace/notarization/process/request-documents-list-container.jsx
+++ b/src/renderer/marketplace/notarization/process/request-documents-list-container.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
-import { Typography, withStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	FileImageIcon,
 	FileDefaultIcon,

--- a/src/renderer/marketplace/notarization/process/request-documents-list-page.jsx
+++ b/src/renderer/marketplace/notarization/process/request-documents-list-page.jsx
@@ -7,9 +7,9 @@ import {
 	TableHead,
 	Typography,
 	Button,
-	withStyles,
 	Checkbox
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { SmallTableHeadRow } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/marketplace/notarization/process/request-notarization-container.jsx
+++ b/src/renderer/marketplace/notarization/process/request-notarization-container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { identitySelectors } from 'common/identity';
 import MarketplaceNotariesComponent from '../common/marketplace-notaries-component';
 import RequestNotarizationPage from './request-notarization-page';

--- a/src/renderer/marketplace/notarization/process/request-notarization-page.jsx
+++ b/src/renderer/marketplace/notarization/process/request-notarization-page.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Button, Typography, IconButton, Divider } from '@material-ui/core';
 import { KeyTooltip, TooltipArrow, InfoTooltip, baseDark, grey, CloseButtonIcon } from 'selfkey-ui';
 import RequestDocumentsList from './request-documents-list-container';

--- a/src/renderer/marketplace/orders/payment-complete.jsx
+++ b/src/renderer/marketplace/orders/payment-complete.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { HourGlassLargeIcon } from 'selfkey-ui';
 import { Popup } from '../../common';

--- a/src/renderer/marketplace/orders/payment.jsx
+++ b/src/renderer/marketplace/orders/payment.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { withStyles, Grid, Typography, Button, IconButton } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Grid, Typography, Button, IconButton } from '@material-ui/core';
 import { Popup } from '../../common';
 import { PaymentIcon, KeyTooltip, InfoTooltip } from 'selfkey-ui';
 

--- a/src/renderer/marketplace/orders/preapprove.jsx
+++ b/src/renderer/marketplace/orders/preapprove.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { withStyles, Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Grid, Typography, Button } from '@material-ui/core';
 import { Popup } from '../../common';
 import { PaymentIcon } from 'selfkey-ui';
 const styles = theme => ({

--- a/src/renderer/marketplace/selfkey-did-required.jsx
+++ b/src/renderer/marketplace/selfkey-did-required.jsx
@@ -1,7 +1,8 @@
 import React, { PureComponent } from 'react';
 import { WarningShieldIcon } from 'selfkey-ui';
 import { Popup } from '../common/popup';
-import { Typography, withStyles, Button, Grid } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	title: {

--- a/src/renderer/marketplace/selfkey-id-required.js
+++ b/src/renderer/marketplace/selfkey-id-required.js
@@ -3,7 +3,8 @@ import { WarningShieldIcon } from 'selfkey-ui';
 import { Popup } from '../common/popup';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
-import { Typography, withStyles, Button, Grid } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	title: {

--- a/src/renderer/no-connection/index.jsx
+++ b/src/renderer/no-connection/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Grid, withStyles, Button } from '@material-ui/core';
+import { Typography, Grid, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { WarningShieldIcon } from 'selfkey-ui';
 import { connect } from 'react-redux';
 import { Popup } from '../common';

--- a/src/renderer/selfkey-id/main/components/edit-avatar.js
+++ b/src/renderer/selfkey-id/main/components/edit-avatar.js
@@ -1,6 +1,7 @@
 /* global FileReader */
 import React, { PureComponent } from 'react';
-import { ButtonBase, withStyles, Button, Grid } from '@material-ui/core';
+import { ButtonBase, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { HexagonAvatar } from './hexagon-avatar';
 const styles = theme => ({});
 

--- a/src/renderer/selfkey-id/main/components/hexagon-avatar.jsx
+++ b/src/renderer/selfkey-id/main/components/hexagon-avatar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import avatarPlaceholder from '../../../../../static/assets/images/icons/icon-add-image.svg';
 const styles = theme => ({
 	hexagon: {

--- a/src/renderer/selfkey-id/main/components/selfkey-id-applications.jsx
+++ b/src/renderer/selfkey-id/main/components/selfkey-id-applications.jsx
@@ -11,10 +11,9 @@ import {
 	Divider,
 	ExpansionPanelDetails,
 	List,
-	ListItem,
-	createStyles,
-	withStyles
+	ListItem
 } from '@material-ui/core';
+import { createStyles, withStyles } from '@material-ui/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import {

--- a/src/renderer/selfkey-id/main/components/selfkey-id-create-about.jsx
+++ b/src/renderer/selfkey-id/main/components/selfkey-id-create-about.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Grid, Typography, Button, withStyles } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Link } from 'react-router-dom';
 import history from 'common/store/history';
 import { Popup } from '../../../common';

--- a/src/renderer/selfkey-id/main/components/selfkey-id-create-disclaimer.jsx
+++ b/src/renderer/selfkey-id/main/components/selfkey-id-create-disclaimer.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Grid, Typography, withStyles, Button } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Link } from 'react-router-dom';
 import history from 'common/store/history';
 import { Popup } from '../../../common';

--- a/src/renderer/selfkey-id/main/components/selfkey-id-create-form.jsx
+++ b/src/renderer/selfkey-id/main/components/selfkey-id-create-form.jsx
@@ -1,13 +1,6 @@
 import React, { PureComponent } from 'react';
-import {
-	Grid,
-	Button,
-	Typography,
-	withStyles,
-	Divider,
-	Input,
-	IconButton
-} from '@material-ui/core';
+import { Grid, Button, Typography, Divider, Input, IconButton } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	IdCardIcon,
 	ModalWrap,

--- a/src/renderer/selfkey-id/main/components/selfkey-id-create.jsx
+++ b/src/renderer/selfkey-id/main/components/selfkey-id-create.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Grid, Modal, Button, Typography, Card, CardContent, withStyles } from '@material-ui/core';
+import { Grid, Modal, Button, Typography, Card, CardContent } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { IdCardIcon, SKIDIcon, ModalWrap } from 'selfkey-ui';
 import { Link } from 'react-router-dom';
 

--- a/src/renderer/selfkey-id/main/components/selfkey-id-overview.jsx
+++ b/src/renderer/selfkey-id/main/components/selfkey-id-overview.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import moment from 'moment';
-
 import {
 	Grid,
 	CardHeader,
@@ -13,9 +12,9 @@ import {
 	IconButton,
 	TableHead,
 	Typography,
-	Button,
-	withStyles
+	Button
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	EditTransparentIcon,
 	DeleteIcon,

--- a/src/renderer/settings/terms-warning.jsx
+++ b/src/renderer/settings/terms-warning.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Grid, Typography, Button } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Popup } from '../common';

--- a/src/renderer/settings/terms.jsx
+++ b/src/renderer/settings/terms.jsx
@@ -9,7 +9,7 @@ import {
 	Checkbox,
 	FormControlLabel
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { appOperations } from 'common/app';
 import { push } from 'connected-react-router';

--- a/src/renderer/transaction/common/transaction-box.jsx
+++ b/src/renderer/transaction/common/transaction-box.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, Typography } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Erc20Icon } from 'selfkey-ui';
 import Popup from '../../common/popup';
 

--- a/src/renderer/transaction/common/transaction-error-box.jsx
+++ b/src/renderer/transaction/common/transaction-error-box.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Grid, withStyles, Typography, Divider } from '@material-ui/core';
+import { Grid, Typography, Divider } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { WarningShieldIcon, Copy } from 'selfkey-ui';
 import Popup from '../../common/popup';
 

--- a/src/renderer/transaction/progress/components/transaction-send-progress-box.js
+++ b/src/renderer/transaction/progress/components/transaction-send-progress-box.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { TransactionBox } from '../../common/transaction-box';
-import { Grid, Typography, withStyles, Button } from '@material-ui/core';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { HourGlassLargeIcon, OkayIcon, NumberFormat } from 'selfkey-ui';
 import config from 'common/config';
 

--- a/src/renderer/transaction/receive/index.jsx
+++ b/src/renderer/transaction/receive/index.jsx
@@ -11,7 +11,7 @@ import {
 	PrintSmallIcon
 } from 'selfkey-ui';
 import { Link } from 'react-router-dom';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import QRCode from 'qrcode.react';
 import { Popup } from '../../common';
 

--- a/src/renderer/transaction/send/advanced-transaction.jsx
+++ b/src/renderer/transaction/send/advanced-transaction.jsx
@@ -6,7 +6,7 @@ import { transactionOperations, transactionSelectors } from 'common/transaction'
 import { getLocale } from 'common/locale/selectors';
 import { getFiatCurrency } from 'common/fiatCurrency/selectors';
 import { getTokens } from 'common/wallet-tokens/selectors';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import {
 	MenuItem,
 	Select,

--- a/src/renderer/transaction/send/containers/transaction-fee-box.jsx
+++ b/src/renderer/transaction/send/containers/transaction-fee-box.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { ActualTransactionFeeBox } from 'renderer/transaction/send/containers/actual-transaction-fee-box';
-import { Grid, withStyles } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Loop as LoopIcon } from '@material-ui/icons';
 
 const styles = theme => ({

--- a/src/renderer/transaction/send/index.jsx
+++ b/src/renderer/transaction/send/index.jsx
@@ -8,7 +8,7 @@ import {
 import { Grid, Typography, Divider, Button } from '@material-ui/core';
 import { SelfkeyIcon, EthereumIcon, CustomIcon, SentIcon, Copy } from 'selfkey-ui';
 import { Link } from 'react-router-dom';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import TokenPrice from '../../common/token-price';
 import { push } from 'connected-react-router';
 import TransactionsHistory from '../transactions-history';

--- a/src/renderer/transaction/send/timer.jsx
+++ b/src/renderer/transaction/send/timer.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Grid, withStyles } from '@material-ui/core';
+import { Typography, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../common/popup';
 import { HourGlassLargeIcon } from 'selfkey-ui';

--- a/src/renderer/transaction/swap/index.jsx
+++ b/src/renderer/transaction/swap/index.jsx
@@ -11,7 +11,7 @@ import { tokenSwapOperations, tokenSwapSelectors } from 'common/token-swap';
 import { convertExponentialToDecimal } from 'common/utils/exponential-to-decimal';
 import { transactionOperations } from 'common/transaction';
 import { MenuItem, Grid, Select, Input, Typography, Button, Divider } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { KeyboardArrowDown } from '@material-ui/icons';
 import { NumberFormat, TransferIcon } from 'selfkey-ui';
 

--- a/src/renderer/transaction/transaction-declined/components/transaction-declined.jsx
+++ b/src/renderer/transaction/transaction-declined/components/transaction-declined.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import TransactionErrorBox from '../../common/transaction-error-box';
-import { Typography, withStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	bodyText: {

--- a/src/renderer/transaction/transaction-error/components/transaction-error.jsx
+++ b/src/renderer/transaction/transaction-error/components/transaction-error.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import TransactionErrorBox from '../../common/transaction-error-box';
-import { Typography, withStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	bodyText: {

--- a/src/renderer/transaction/transaction-no-gas-error/components/transaction-no-gas-error.jsx
+++ b/src/renderer/transaction/transaction-no-gas-error/components/transaction-no-gas-error.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import TransactionErrorBox from '../../common/transaction-error-box';
-import { withStyles, Typography } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	bodyText: {

--- a/src/renderer/transaction/transaction-no-key-error/components/transaction-no-key-error.jsx
+++ b/src/renderer/transaction/transaction-no-key-error/components/transaction-no-key-error.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import TransactionErrorBox from '../../common/transaction-error-box';
-import { withStyles, Typography, List, ListItem } from '@material-ui/core';
+import { Typography, List, ListItem } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { DefaultBullet } from 'selfkey-ui';
 
 const styles = theme => ({

--- a/src/renderer/transaction/transaction-timeout/index.jsx
+++ b/src/renderer/transaction/transaction-timeout/index.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import Popup from '../../common/popup';
 import { appSelectors } from 'common/app';

--- a/src/renderer/transaction/transaction-unlock/index.jsx
+++ b/src/renderer/transaction/transaction-unlock/index.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Typography, Button, Grid, withStyles } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { UnlockLargeIcon } from 'selfkey-ui';
 import { connect } from 'react-redux';
 import history from 'common/store/history';

--- a/src/renderer/transaction/transactions-history-modal/index.jsx
+++ b/src/renderer/transaction/transactions-history-modal/index.jsx
@@ -25,7 +25,7 @@ import {
 	Input,
 	FormControl
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import {
 	HourGlassIcon,
 	FailedIcon,

--- a/src/renderer/transaction/transactions-history/index.jsx
+++ b/src/renderer/transaction/transactions-history/index.jsx
@@ -18,7 +18,7 @@ import {
 	TableFooter,
 	CircularProgress
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import {
 	RefreshIcon,
 	HourGlassIcon,

--- a/src/renderer/wallet/create/backup-address.jsx
+++ b/src/renderer/wallet/create/backup-address.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Grid, Typography, Input, Button, InputAdornment } from '@material-ui/core';
 import { Copy, DownloadIcon2, warning } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { walletSelectors } from 'common/wallet';
 import { createWalletSelectors, createWalletOperations } from 'common/create-wallet';

--- a/src/renderer/wallet/create/backup-pk.jsx
+++ b/src/renderer/wallet/create/backup-pk.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Grid, Typography, Input, Button, InputAdornment } from '@material-ui/core';
 import { PrintIcon, VisibilityOnIcon, VisibilityOffIcon, warning } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { walletSelectors } from 'common/wallet';
 import { Link } from 'react-router-dom';

--- a/src/renderer/wallet/create/index.jsx
+++ b/src/renderer/wallet/create/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Typography, Grid, Button, withStyles } from '@material-ui/core';
+import { Typography, Grid, Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Link } from 'react-router-dom';
 import { WarningShieldIcon, warning } from 'selfkey-ui';
 import { Popup } from '../../common';

--- a/src/renderer/wallet/create/password/confirmation.jsx
+++ b/src/renderer/wallet/create/password/confirmation.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Typography, Input, LinearProgress, Button } from '@material-ui/core';
 import { PasswordConfirmIcon } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { handlePassword, renderPasswordStrength } from './password-util';
 import { createWalletSelectors, createWalletOperations } from 'common/create-wallet';
 import { push } from 'connected-react-router';

--- a/src/renderer/wallet/create/password/index.jsx
+++ b/src/renderer/wallet/create/password/index.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Grid, Typography, Input, LinearProgress, Button } from '@material-ui/core';
 import { PasswordIcon } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Link } from 'react-router-dom';
 import { handlePassword, renderPasswordStrength } from './password-util';
 import { connect } from 'react-redux';

--- a/src/renderer/wallet/main/export-qr-code.js
+++ b/src/renderer/wallet/main/export-qr-code.js
@@ -1,7 +1,8 @@
 import React, { PureComponent } from 'react';
 import QRCode from 'qrcode.react';
 import { Popup } from '../../common/popup';
-import { Typography, withStyles, Button, Grid, CircularProgress } from '@material-ui/core';
+import { Typography, Button, Grid, CircularProgress } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	title: {

--- a/src/renderer/wallet/main/export-warning.js
+++ b/src/renderer/wallet/main/export-warning.js
@@ -1,7 +1,8 @@
 import React, { PureComponent } from 'react';
 import { WarningShieldIcon } from 'selfkey-ui';
 import { Popup } from '../../common/popup';
-import { Typography, withStyles, Button, Grid } from '@material-ui/core';
+import { Typography, Button, Grid } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	title: {

--- a/src/renderer/wallet/main/index.jsx
+++ b/src/renderer/wallet/main/index.jsx
@@ -25,8 +25,8 @@ import Transfer from '../../transaction/send';
 import AdvancedTransaction from '../../transaction/send/advanced-transaction';
 import ReceiveTransfer from '../../transaction/receive';
 import TokenSwap from '../../transaction/swap';
-
-import { Grid, withStyles } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { Grid } from '@material-ui/core';
 import Toolbar from './toolbar-container';
 import { connect } from 'react-redux';
 

--- a/src/renderer/wallet/main/sidebar-switch-account.jsx
+++ b/src/renderer/wallet/main/sidebar-switch-account.jsx
@@ -1,14 +1,6 @@
 import React, { PureComponent } from 'react';
-import {
-	withStyles,
-	Button,
-	Drawer,
-	Grid,
-	List,
-	ListItem,
-	Typography,
-	Divider
-} from '@material-ui/core';
+import { Button, Drawer, Grid, List, ListItem, Typography, Divider } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import Close from '@material-ui/icons/Close';
 import { SelfkeyLogo } from 'selfkey-ui';
 import PersonIcon from 'selfkey-ui/build/lib/icons/person';

--- a/src/renderer/wallet/main/sidebar.jsx
+++ b/src/renderer/wallet/main/sidebar.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import {
-	withStyles,
 	List,
 	ListItem,
 	Drawer,
@@ -13,6 +12,7 @@ import {
 	// IconButton
 	Divider
 } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import { Link } from 'react-router-dom';
 import {
 	DashboardMenuIcon,

--- a/src/renderer/wallet/main/toolbar.jsx
+++ b/src/renderer/wallet/main/toolbar.jsx
@@ -1,12 +1,6 @@
 import React, { PureComponent } from 'react';
-import {
-	createStyles,
-	withStyles,
-	Button,
-	Grid,
-	Typography,
-	ClickAwayListener
-} from '@material-ui/core';
+import { Button, Grid, Typography, ClickAwayListener } from '@material-ui/core';
+import { createStyles, withStyles } from '@material-ui/styles';
 import {
 	MenuNewIcon,
 	DropdownIcon,

--- a/src/renderer/wallet/unlock/existing-address.jsx
+++ b/src/renderer/wallet/unlock/existing-address.jsx
@@ -9,7 +9,7 @@ import {
 	MenuItem,
 	FormControl
 } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { appOperations, appSelectors } from 'common/app';
 import { KeyboardArrowDown } from '@material-ui/icons';

--- a/src/renderer/wallet/unlock/index.jsx
+++ b/src/renderer/wallet/unlock/index.jsx
@@ -9,7 +9,7 @@ import {
 	LedgerIcon,
 	TrezorIcon
 } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { Link, Route, Redirect, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';

--- a/src/renderer/wallet/unlock/ledger/connecting.jsx
+++ b/src/renderer/wallet/unlock/ledger/connecting.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { Typography, Button, Grid } from '@material-ui/core';
 import { HourGlassLargeIcon, WarningShieldIcon } from 'selfkey-ui';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import HelpStepsSection from './help-steps-section';
 import { appOperations, appSelectors } from 'common/app';
 import HelpStepsErrorSection from './help-steps-error-section';

--- a/src/renderer/wallet/unlock/ledger/help-steps-error-section.jsx
+++ b/src/renderer/wallet/unlock/ledger/help-steps-error-section.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, Avatar, Typography } from '@material-ui/core';
+import { Grid, Avatar, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	avatar: {

--- a/src/renderer/wallet/unlock/ledger/help-steps-section.jsx
+++ b/src/renderer/wallet/unlock/ledger/help-steps-section.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, Avatar, Typography } from '@material-ui/core';
+import { Grid, Avatar, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	avatar: {

--- a/src/renderer/wallet/unlock/ledger/index.jsx
+++ b/src/renderer/wallet/unlock/ledger/index.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Button, Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import HelpStepsSection from './help-steps-section';
 import { push } from 'connected-react-router';

--- a/src/renderer/wallet/unlock/new-address.jsx
+++ b/src/renderer/wallet/unlock/new-address.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Avatar, Input, Button, Grid, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { appOperations, appSelectors } from 'common/app';
 

--- a/src/renderer/wallet/unlock/private-key.jsx
+++ b/src/renderer/wallet/unlock/private-key.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Avatar, Input, Button, Grid, Typography, InputAdornment } from '@material-ui/core';
 import { VisibilityOffIcon, VisibilityOnIcon } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { appOperations, appSelectors } from 'common/app';
 

--- a/src/renderer/wallet/unlock/select-address.jsx
+++ b/src/renderer/wallet/unlock/select-address.jsx
@@ -1,14 +1,6 @@
 import React, { PureComponent } from 'react';
-import {
-	Typography,
-	Button,
-	Grid,
-	Table,
-	TableHead,
-	Radio,
-	TableBody,
-	withStyles
-} from '@material-ui/core';
+import { Typography, Button, Grid, Table, TableHead, Radio, TableBody } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 import {
 	ViewIcon,
 	SmallTableRow,

--- a/src/renderer/wallet/unlock/trezor/connecting.jsx
+++ b/src/renderer/wallet/unlock/trezor/connecting.jsx
@@ -16,7 +16,7 @@ import {
 	WarningShieldIcon,
 	TrezorBridgeIcon
 } from 'selfkey-ui';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import { appOperations, appSelectors } from 'common/app';
 import { push } from 'connected-react-router';

--- a/src/renderer/wallet/unlock/trezor/enter-passphrase.jsx
+++ b/src/renderer/wallet/unlock/trezor/enter-passphrase.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Typography, Grid, Button, Input, InputAdornment } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
-
+import { withStyles } from '@material-ui/styles';
 import { VisibilityOffIcon, VisibilityOnIcon } from 'selfkey-ui';
 import { connect } from 'react-redux';
 import { appOperations, appSelectors } from 'common/app';

--- a/src/renderer/wallet/unlock/trezor/enter-pin.jsx
+++ b/src/renderer/wallet/unlock/trezor/enter-pin.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Typography, Grid, Paper, Button, Input, InputAdornment } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 
 import { ClearIcon } from 'selfkey-ui';
 import { connect } from 'react-redux';

--- a/src/renderer/wallet/unlock/trezor/help-steps-section.jsx
+++ b/src/renderer/wallet/unlock/trezor/help-steps-section.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { withStyles, Grid, Avatar, Typography } from '@material-ui/core';
+import { Grid, Avatar, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
 
 const styles = theme => ({
 	avatar: {

--- a/src/renderer/wallet/unlock/trezor/index.jsx
+++ b/src/renderer/wallet/unlock/trezor/index.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Button, Grid } from '@material-ui/core';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { connect } from 'react-redux';
 import HelpStepsSection from './help-steps-section';
 import { push } from 'connected-react-router';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,6 +1836,28 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
+"@material-ui/styles@4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.6.tgz#924a30bf7c9b91af9c8f19c12c8573b8a4ecd085"
+  integrity sha512-ijgwStEkw1OZ6gCz18hkjycpr/3lKs1hYPi88O/AUn4vMuuGEGAIrqKVFq/lADmZUNF3DOFIk8LDkp7zmjPxtA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.0.0"
+    "@material-ui/utils" "^4.9.6"
+    clsx "^1.0.2"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.0.3"
+    jss-plugin-camel-case "^10.0.3"
+    jss-plugin-default-unit "^10.0.3"
+    jss-plugin-global "^10.0.3"
+    jss-plugin-nested "^10.0.3"
+    jss-plugin-props-sort "^10.0.3"
+    jss-plugin-rule-value-function "^10.0.3"
+    jss-plugin-vendor-prefixer "^10.0.3"
+    prop-types "^15.7.2"
+
 "@material-ui/styles@^4.9.6":
   version "4.9.10"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.10.tgz#182ccdd0bc8525a459486499bbaebcd92b0db3ab"


### PR DESCRIPTION
Refactor to explicitly use material-ui/styles, it's going to be a separate package starting on v5.

FYI: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/styles/createStyles.js
