### PR TITLE
fix: failing circle ci unit tests with Error: spawn ENOMEM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
                   command: yarn install-all
             - run:
                   name: Unit Tests
-                  command: yarn test:unit:ci -- --maxWorkers=2
+                  command: yarn test:unit:ci --maxWorkers=2
             - run:
                   name: Coveralls
                   command: yarn coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
                   command: yarn install-all
             - run:
                   name: Unit Tests
-                  command: yarn test:unit:ci
+                  command: yarn test:unit:ci -- --maxWorkers=2
             - run:
                   name: Coveralls
                   command: yarn coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,13 +70,13 @@ jobs:
                   command: yarn install-all
             - run:
                   name: Unit Tests
-                  command: yarn test:unit:ci --maxWorkers=2
+                  command: yarn test:unit:ci
             - run:
                   name: Coveralls
                   command: yarn coveralls
-            - run:
-                  name: Build Storybook
-                  command: yarn build-storybook
+            # - run:
+            #       name: Build Storybook
+            #       command: yarn build-storybook
             - persist_to_workspace:
                   root: .
                   paths:


### PR DESCRIPTION
Limits the number of workers in circle-ci jest unit test.
https://support.circleci.com/hc/en-us/articles/360038192673-NodeJS-Builds-or-Test-Suites-Fail-With-ENOMEM-or-a-Timeout