### PR TITLE
fix: remove static token in message displayed in transaction error popup

### DIFF
--- a/src/renderer/transaction/common/transaction-error-box.jsx
+++ b/src/renderer/transaction/common/transaction-error-box.jsx
@@ -7,7 +7,7 @@ import Popup from '../../common/popup';
 const styles = theme => ({});
 
 export const TransactionErrorBox = withStyles(styles)(
-	({ children, address, closeAction, open = true, subtitle }) => (
+	({ children, address, closeAction, open = true, subtitle, token = 'KEY' }) => (
 		<Popup open={open} closeAction={closeAction} text="Transaction Notice">
 			<Grid container direction="row" justify="flex-start" alignItems="flex-start">
 				<Grid item xs={2}>
@@ -21,7 +21,7 @@ export const TransactionErrorBox = withStyles(styles)(
 							<>
 								<Divider />
 								<Typography variant="body1" color="secondary">
-									Your Address to receive KEY:
+									Your Address to receive {token}:
 								</Typography>
 								<Grid container alignItems="center">
 									<Typography variant="body1">{address}</Typography>

--- a/src/renderer/transaction/transaction-no-gas-error/components/transaction-no-gas-error.jsx
+++ b/src/renderer/transaction/transaction-no-gas-error/components/transaction-no-gas-error.jsx
@@ -33,7 +33,7 @@ export const TransactionNoGasError = withStyles(styles)(
 			openLink(gasExplanationUrl);
 		};
 		return (
-			<TransactionErrorBox address={address} closeAction={closeAction}>
+			<TransactionErrorBox address={address} closeAction={closeAction} token="ETH">
 				<div className={classes.bodyText}>
 					<Typography variant="body1">
 						You do not have enough Ethereum (ETH) to pay for the network transaction

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,7 +1232,7 @@
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-"@emotion/cache@^10.0.27":
+"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
@@ -1254,7 +1254,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27":
+"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==


### PR DESCRIPTION
Fixes:
![80465493-c6ebbc80-896d-11ea-8bdc-484015e3467a](https://user-images.githubusercontent.com/1074/81050450-e9bf2900-8eb7-11ea-8767-45c46f012e6f.png)
