### PR TITLE
2198 support multiple fiat currencies

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -57,6 +57,8 @@ const common = {
 	userAgent: `SelfKeyIDW/${pkg.version}`,
 	airtableBaseUrl: 'https://us-central1-kycchain-master.cloudfunctions.net/airtable?tableName=',
 
+	exchangeRateApiUrl: 'https://api.exchangeratesapi.io',
+
 	kyccUrlOverride: KYCC_API_OVERRIDE,
 	incorporationsPriceOverride: INCORPORATIONS_PRICE_OVERRIDE,
 	incorporationsTemplateOverride: INCORPORATIONS_TEMPLATE_OVERRIDE,

--- a/src/common/fiatCurrency/actions.js
+++ b/src/common/fiatCurrency/actions.js
@@ -6,7 +6,7 @@ const fiatCurrencyUpdate = fiatCurrency => ({
 });
 
 const setExchangeRates = rates => ({
-	type: types.LOAD_EXCHANGE_RATES,
+	type: types.SET_EXCHANGE_RATES,
 	payload: rates
 });
 

--- a/src/common/fiatCurrency/actions.js
+++ b/src/common/fiatCurrency/actions.js
@@ -5,4 +5,9 @@ const fiatCurrencyUpdate = fiatCurrency => ({
 	payload: fiatCurrency
 });
 
-export { fiatCurrencyUpdate };
+const setExchangeRates = rates => ({
+	type: types.LOAD_EXCHANGE_RATES,
+	payload: rates
+});
+
+export { fiatCurrencyUpdate, setExchangeRates };

--- a/src/common/fiatCurrency/operations.js
+++ b/src/common/fiatCurrency/operations.js
@@ -1,10 +1,16 @@
 import { getGlobalContext } from 'common/context';
+import { createAliasedAction } from 'electron-redux';
 import * as actions from './actions';
+import * as types from './types';
 
-const loadExchangeRatesOperation = () => async (dispatch, getState) => {
+const loadExchangeRates = () => async (dispatch, getState) => {
 	const ctx = getGlobalContext();
-	const rates = await ctx.CurrencyService.fetchRates();
+	const rates = await ctx.currencyService.fetchRates();
+	console.log('here');
 	await dispatch(actions.setExchangeRates(rates));
 };
 
-export default { loadExchangeRatesOperation, ...actions };
+export default {
+	loadExchangeRatesOperation: createAliasedAction(types.LOAD_EXCHANGE_RATES, loadExchangeRates),
+	...actions
+};

--- a/src/common/fiatCurrency/operations.js
+++ b/src/common/fiatCurrency/operations.js
@@ -6,7 +6,6 @@ import * as types from './types';
 const loadExchangeRates = () => async (dispatch, getState) => {
 	const ctx = getGlobalContext();
 	const rates = await ctx.currencyService.fetchRates();
-	console.log('here');
 	await dispatch(actions.setExchangeRates(rates));
 };
 

--- a/src/common/fiatCurrency/operations.js
+++ b/src/common/fiatCurrency/operations.js
@@ -1,3 +1,10 @@
+import { getGlobalContext } from 'common/context';
 import * as actions from './actions';
 
-export default { ...actions };
+const loadExchangeRatesOperation = () => async (dispatch, getState) => {
+	const ctx = getGlobalContext();
+	const rates = await ctx.CurrencyService.fetchRates();
+	await dispatch(actions.setExchangeRates(rates));
+};
+
+export default { loadExchangeRatesOperation, ...actions };

--- a/src/common/fiatCurrency/reducers.js
+++ b/src/common/fiatCurrency/reducers.js
@@ -2,7 +2,7 @@ import * as types from './types';
 
 const initialState = {
 	fiatCurrency: 'USD',
-	fiatRates: []
+	fiatRates: {}
 };
 
 const fiatCurrencyReducer = (state = initialState, action) => {
@@ -12,9 +12,9 @@ const fiatCurrencyReducer = (state = initialState, action) => {
 				...state,
 				fiatCurrency: action.payload
 			};
-		case types.LOAD_EXCHANGE_RATES:
+		case types.SET_EXCHANGE_RATES:
 			return {
-				state,
+				...state,
 				fiatRates: action.payload
 			};
 		default:

--- a/src/common/fiatCurrency/reducers.js
+++ b/src/common/fiatCurrency/reducers.js
@@ -1,7 +1,8 @@
 import * as types from './types';
 
 const initialState = {
-	fiatCurrency: 'USD'
+	fiatCurrency: 'USD',
+	fiatRates: []
 };
 
 const fiatCurrencyReducer = (state = initialState, action) => {
@@ -10,6 +11,11 @@ const fiatCurrencyReducer = (state = initialState, action) => {
 			return {
 				...state,
 				fiatCurrency: action.payload
+			};
+		case types.LOAD_EXCHANGE_RATES:
+			return {
+				state,
+				fiatRates: action.payload
 			};
 		default:
 			return state;

--- a/src/common/fiatCurrency/selectors.js
+++ b/src/common/fiatCurrency/selectors.js
@@ -1,5 +1,13 @@
 const getFiatCurrency = state => state.fiatCurrency;
 
-const getFiatRates = state => state.fiatRates;
+const selectFiatRates = state => getFiatCurrency(state).fiatRates;
 
-export { getFiatCurrency, getFiatRates };
+const selectExchangeRate = (state, currency) => {
+	const rates = selectFiatRates(state);
+	if (currency && rates[currency]) {
+		return rates[currency];
+	}
+	return 1;
+};
+
+export { getFiatCurrency, selectFiatRates, selectExchangeRate };

--- a/src/common/fiatCurrency/selectors.js
+++ b/src/common/fiatCurrency/selectors.js
@@ -1,1 +1,5 @@
-export const getFiatCurrency = state => state.fiatCurrency;
+const getFiatCurrency = state => state.fiatCurrency;
+
+const getFiatRates = state => state.fiatRates;
+
+export { getFiatCurrency, getFiatRates };

--- a/src/common/fiatCurrency/types.js
+++ b/src/common/fiatCurrency/types.js
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 const FIAT_CURRENCY_UPDATE = 'app/fiatCurrency/UPDATE';
 const LOAD_EXCHANGE_RATES = 'app/fiatCurrency/LOAD_RATES';
+const SET_EXCHANGE_RATES = 'app/fiatCurrency/SET_RATES';
 
-export { FIAT_CURRENCY_UPDATE, LOAD_EXCHANGE_RATES };
+export { FIAT_CURRENCY_UPDATE, LOAD_EXCHANGE_RATES, SET_EXCHANGE_RATES };

--- a/src/common/fiatCurrency/types.js
+++ b/src/common/fiatCurrency/types.js
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
 const FIAT_CURRENCY_UPDATE = 'app/fiatCurrency/UPDATE';
+const LOAD_EXCHANGE_RATES = 'app/fiatCurrency/LOAD_RATES';
 
-export { FIAT_CURRENCY_UPDATE };
+export { FIAT_CURRENCY_UPDATE, LOAD_EXCHANGE_RATES };

--- a/src/common/token-swap/index.js
+++ b/src/common/token-swap/index.js
@@ -80,7 +80,7 @@ const setTargetOperation = token => async (dispatch, getState) => {
 
 const loadTokensOperation = () => async (dispatch, getState) => {
 	const ctx = getGlobalContext();
-	const tokens = await ctx.TotleSwapService.fetchTokens();
+	const tokens = await ctx.totleSwapService.fetchTokens();
 	await dispatch(tokenSwapActions.setTokens(tokens));
 };
 
@@ -97,7 +97,7 @@ const swapTokensOperation = ({ address, amount, decimal }) => async (dispatch, g
 		destinationAsset,
 		sourceAmount: toBaseUnit(amount, decimal)
 	};
-	const request = await ctx.TotleSwapService.swap(
+	const request = await ctx.totleSwapService.swap(
 		address,
 		swapRequestPayload,
 		partnerContractAddress

--- a/src/main/context.js
+++ b/src/main/context.js
@@ -36,6 +36,7 @@ import { PaymentService } from './blockchain/payment-service';
 import { SelfkeyService } from './blockchain/selfkey-service';
 import { MarketplaceOrdersService } from './marketplace/orders/orders-service';
 import { TotleSwapService } from './token-swap/totle-service';
+import { CurrencyService } from './currency/currency-service';
 
 export const registerMainServices = container => {
 	container.register({
@@ -80,6 +81,7 @@ export const registerMainServices = container => {
 		didService: asClass(DIDService).singleton(),
 		autoUpdateService: asClass(AutoUpdateService).singleton(),
 		marketplaceOrdersService: asClass(MarketplaceOrdersService).singleton(),
-		TotleSwapService: asClass(TotleSwapService).singleton()
+		TotleSwapService: asClass(TotleSwapService).singleton(),
+		CurrencyService: asClass(CurrencyService).singleton()
 	});
 };

--- a/src/main/context.js
+++ b/src/main/context.js
@@ -81,7 +81,7 @@ export const registerMainServices = container => {
 		didService: asClass(DIDService).singleton(),
 		autoUpdateService: asClass(AutoUpdateService).singleton(),
 		marketplaceOrdersService: asClass(MarketplaceOrdersService).singleton(),
-		TotleSwapService: asClass(TotleSwapService).singleton(),
-		CurrencyService: asClass(CurrencyService).singleton()
+		totleSwapService: asClass(TotleSwapService).singleton(),
+		currencyService: asClass(CurrencyService).singleton()
 	});
 };

--- a/src/main/currency/currency-service.js
+++ b/src/main/currency/currency-service.js
@@ -13,7 +13,7 @@ export class CurrencyService {
 				url: `${EXCHANGE_RATE_ENDPOINT}/latest?base=USD`,
 				json: true
 			});
-			return fetched.rates ? fetched.rates : [];
+			return fetched.rates ? fetched.rates : {};
 		} catch (error) {
 			log.error(error);
 			return [];

--- a/src/main/currency/currency-service.js
+++ b/src/main/currency/currency-service.js
@@ -1,0 +1,24 @@
+import config from 'common/config';
+import request from 'request-promise-native';
+import { Logger } from '../../common/logger';
+
+const log = new Logger('CurrencyService');
+
+const EXCHANGE_RATE_ENDPOINT = config.exchangeRateApiUrl;
+
+export class CurrencyService {
+	async fetchRates() {
+		try {
+			const fetched = await request.get({
+				url: `${EXCHANGE_RATE_ENDPOINT}/latest?base=USD`,
+				json: true
+			});
+			return fetched.rates ? fetched.rates : [];
+		} catch (error) {
+			log.error(error);
+			return [];
+		}
+	}
+}
+
+export default CurrencyService;

--- a/src/renderer/marketplace/categories/categories-list.jsx
+++ b/src/renderer/marketplace/categories/categories-list.jsx
@@ -62,7 +62,7 @@ export const MarketplaceCategoriesList = withStyles(styles)(({ classes, children
 				<Typography variant="h1">SelfKey Marketplace</Typography>
 			</Grid>
 		</Grid>
-		<Grid container xs={12}>
+		<Grid container>
 			<hr className={classes.hr} />
 		</Grid>
 		<Grid item id="body" xs={12}>

--- a/src/renderer/marketplace/loans/calculator/borrow-table.jsx
+++ b/src/renderer/marketplace/loans/calculator/borrow-table.jsx
@@ -35,81 +35,83 @@ const styles = theme => ({
 	}
 });
 
-const LoansCalculatorBorrowTable = withStyles(styles)(({ classes, data, onDetailsClick }) => (
-	<Table className={classes.table}>
-		<TableHead>
-			<LargeTableHeadRow>
-				<TableCell className={classes.logoCell} />
-				<TableCell>
-					<Typography variant="overline">Name</Typography>
-				</TableCell>
-				{/*
+const LoansCalculatorBorrowTable = withStyles(styles)(
+	({ classes, data, currency, onDetailsClick }) => (
+		<Table className={classes.table}>
+			<TableHead>
+				<LargeTableHeadRow>
+					<TableCell className={classes.logoCell} />
+					<TableCell>
+						<Typography variant="overline">Name</Typography>
+					</TableCell>
+					{/*
 					<TableCell>
 						<Typography variant="overline">Trust Score</Typography>
 					</TableCell>
-				*/}
-				<TableCell>
-					<Typography variant="overline">Type</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Collateral Needed</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Interest Rate</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Interest Amount</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Monthly Payment</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Repayment Amount</Typography>
-				</TableCell>
-				<TableCell className={classes.detailsCell} />
-			</LargeTableHeadRow>
-		</TableHead>
-		<TableBody className={classes.tableBodyRow}>
-			{data.map(offer => (
-				<TableRow key={offer.sku}>
-					<TableCell className={classes.logoCell}>
-						{offer.data.logoUrl && <img src={offer.data.logoUrl} />}
-					</TableCell>
-					<TableCell>{offer.name}</TableCell>
-					{/*
-					<TableCell />
 					*/}
 					<TableCell>
-						{offer.data.type === 'Decentralized' ? 'P2P' : 'Centralized'}
-					</TableCell>
-					<TableCell>{offer.collateral}</TableCell>
-					<TableCell>{offer.data.interestRate}</TableCell>
-					<TableCell>
-						{offer.loanPayment.totalInterest.toLocaleString('en-US', {
-							style: 'currency',
-							currency: 'USD'
-						})}
+						<Typography variant="overline">Type</Typography>
 					</TableCell>
 					<TableCell>
-						{offer.loanPayment.monthly.toLocaleString('en-US', {
-							style: 'currency',
-							currency: 'USD'
-						})}
+						<Typography variant="overline">Collateral Needed</Typography>
 					</TableCell>
 					<TableCell>
-						{parseFloat(offer.loanPayment.total).toLocaleString('en-US', {
-							style: 'currency',
-							currency: 'USD'
-						})}
+						<Typography variant="overline">Interest Rate</Typography>
 					</TableCell>
-					<TableCell className={classes.detailsCell}>
-						<DetailsButton onClick={() => onDetailsClick(offer)} />
+					<TableCell>
+						<Typography variant="overline">Interest Amount</Typography>
 					</TableCell>
-				</TableRow>
-			))}
-		</TableBody>
-	</Table>
-));
+					<TableCell>
+						<Typography variant="overline">Monthly Payment</Typography>
+					</TableCell>
+					<TableCell>
+						<Typography variant="overline">Repayment Amount</Typography>
+					</TableCell>
+					<TableCell className={classes.detailsCell} />
+				</LargeTableHeadRow>
+			</TableHead>
+			<TableBody className={classes.tableBodyRow}>
+				{data.map(offer => (
+					<TableRow key={offer.sku}>
+						<TableCell className={classes.logoCell}>
+							{offer.data.logoUrl && <img src={offer.data.logoUrl} />}
+						</TableCell>
+						<TableCell>{offer.name}</TableCell>
+						{/*
+							<TableCell />
+						*/}
+						<TableCell>
+							{offer.data.type === 'Decentralized' ? 'P2P' : 'Centralized'}
+						</TableCell>
+						<TableCell>{offer.collateral}</TableCell>
+						<TableCell>{offer.data.interestRate}</TableCell>
+						<TableCell>
+							{offer.loanPayment.totalInterest.toLocaleString('en-US', {
+								style: 'currency',
+								currency
+							})}
+						</TableCell>
+						<TableCell>
+							{offer.loanPayment.monthly.toLocaleString('en-US', {
+								style: 'currency',
+								currency
+							})}
+						</TableCell>
+						<TableCell>
+							{parseFloat(offer.loanPayment.total).toLocaleString('en-US', {
+								style: 'currency',
+								currency
+							})}
+						</TableCell>
+						<TableCell className={classes.detailsCell}>
+							<DetailsButton onClick={() => onDetailsClick(offer)} />
+						</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	)
+);
 
 export default LoansCalculatorBorrowTable;
 export { LoansCalculatorBorrowTable };

--- a/src/renderer/marketplace/loans/calculator/index.jsx
+++ b/src/renderer/marketplace/loans/calculator/index.jsx
@@ -71,6 +71,7 @@ const styles = theme => ({
 });
 
 const FIXED_TOKENS = ['BTC', 'ETH', 'KEY'];
+const CURRENCIES = ['USD', 'EUR'];
 
 const calculateCollateral = ({ amount, token, rates, ltv }) => {
 	const rate = rates.find(r => r.symbol === token);
@@ -111,6 +112,7 @@ const calculateMonthlyPayment = ({ amount, apr, months }) => {
 
 class LoansCalculatorComponent extends MarketplaceLoansComponent {
 	state = {
+		currencyIndex: 0,
 		type: 'borrowing',
 		selectedToken: FIXED_TOKENS[0],
 		amount: '',
@@ -165,6 +167,12 @@ class LoansCalculatorComponent extends MarketplaceLoansComponent {
 		this.setState({ amount });
 	};
 
+	onCurrencyChange = () => {
+		const currencyIndex =
+			this.state.currencyIndex + 1 >= CURRENCIES.length ? 0 : this.state.currencyIndex + 1;
+		this.setState({ currencyIndex });
+	};
+
 	onPeriodChange = (e, period) => {
 		this.setState({ results: [], period });
 	};
@@ -174,6 +182,8 @@ class LoansCalculatorComponent extends MarketplaceLoansComponent {
 	calculate() {
 		const { inventory } = this.props;
 		const { amount, type, period, selectedToken, repayment } = this.state;
+
+		// TODO: convert amount to USD
 
 		// Filter correct type (Lending or Borrowing)
 		const inventoryByType = this.filterLoanType(inventory, type);
@@ -237,7 +247,8 @@ class LoansCalculatorComponent extends MarketplaceLoansComponent {
 
 	render() {
 		const { classes } = this.props;
-		const { type, period, amount, selectedToken, repayment } = this.state;
+		const { type, period, amount, selectedToken, repayment, currencyIndex } = this.state;
+		const currency = CURRENCIES[currencyIndex];
 
 		return (
 			<div className={classes.container}>
@@ -316,8 +327,9 @@ class LoansCalculatorComponent extends MarketplaceLoansComponent {
 										variant="outlined"
 										size="large"
 										className={classes.sourceInput}
+										onClick={this.onCurrencyChange}
 									>
-										USD
+										{currency}
 										<TransferIcon />
 									</Button>
 								</div>

--- a/src/renderer/marketplace/loans/calculator/index.jsx
+++ b/src/renderer/marketplace/loans/calculator/index.jsx
@@ -192,6 +192,11 @@ class LoansCalculatorComponent extends MarketplaceLoansComponent {
 		const { amount, type, period, selectedToken, repayment, currencyIndex } = this.state;
 		const currency = CURRENCIES[currencyIndex];
 
+		// Don't do anything if amount is invalid
+		if (amount <= 0) {
+			return;
+		}
+
 		// Convert to USD
 		const convertedAmount = convertCurrency(amount, currency, fiatRates);
 

--- a/src/renderer/marketplace/loans/calculator/lend-table.jsx
+++ b/src/renderer/marketplace/loans/calculator/lend-table.jsx
@@ -35,72 +35,74 @@ const styles = theme => ({
 	}
 });
 
-const LoansCalculatorLendTable = withStyles(styles)(({ classes, data, onDetailsClick }) => (
-	<Table className={classes.table}>
-		<TableHead>
-			<LargeTableHeadRow>
-				<TableCell className={classes.logoCell} />
-				<TableCell>
-					<Typography variant="overline">Name</Typography>
-				</TableCell>
-				{/*
+const LoansCalculatorLendTable = withStyles(styles)(
+	({ classes, data, currency, onDetailsClick }) => (
+		<Table className={classes.table}>
+			<TableHead>
+				<LargeTableHeadRow>
+					<TableCell className={classes.logoCell} />
+					<TableCell>
+						<Typography variant="overline">Name</Typography>
+					</TableCell>
+					{/*
 					<TableCell>
 						<Typography variant="overline">Trust Score</Typography>
 					</TableCell>
 					*/}
-				<TableCell>
-					<Typography variant="overline">Type</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Assets Accepted</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Interest Rate</Typography>
-				</TableCell>
-				<TableCell>
-					<Typography variant="overline">Revenue</Typography>
-				</TableCell>
-				<TableCell className={classes.detailsCell} />
-			</LargeTableHeadRow>
-		</TableHead>
-		<TableBody className={classes.tableBodyRow}>
-			{data.map(offer => (
-				<TableRow key={offer.sku}>
-					<TableCell className={classes.logoCell}>
-						{offer.data.logoUrl && <img src={offer.data.logoUrl} />}
+					<TableCell>
+						<Typography variant="overline">Type</Typography>
 					</TableCell>
-					<TableCell>{offer.name}</TableCell>
-					{/*
+					<TableCell>
+						<Typography variant="overline">Assets Accepted</Typography>
+					</TableCell>
+					<TableCell>
+						<Typography variant="overline">Interest Rate</Typography>
+					</TableCell>
+					<TableCell>
+						<Typography variant="overline">Revenue</Typography>
+					</TableCell>
+					<TableCell className={classes.detailsCell} />
+				</LargeTableHeadRow>
+			</TableHead>
+			<TableBody className={classes.tableBodyRow}>
+				{data.map(offer => (
+					<TableRow key={offer.sku}>
+						<TableCell className={classes.logoCell}>
+							{offer.data.logoUrl && <img src={offer.data.logoUrl} />}
+						</TableCell>
+						<TableCell>{offer.name}</TableCell>
+						{/*
 					<TableCell />
 					*/}
-					<TableCell>
-						{offer.data.type === 'Decentralized' ? 'P2P' : 'Centralized'}
-					</TableCell>
-					<TableCell>
-						<Grid container>
-							{offer.data.assets &&
-								offer.data.assets.map(tag => (
-									<Tag key={tag} onClick={() => this.selectToken(tag)}>
-										{tag}
-									</Tag>
-								))}
-						</Grid>
-					</TableCell>
-					<TableCell>{offer.data.interestRate}</TableCell>
-					<TableCell>
-						{offer.loanPayment.totalInterest.toLocaleString('en-US', {
-							style: 'currency',
-							currency: 'USD'
-						})}
-					</TableCell>
-					<TableCell className={classes.detailsCell}>
-						<DetailsButton onClick={() => onDetailsClick(offer)} />
-					</TableCell>
-				</TableRow>
-			))}
-		</TableBody>
-	</Table>
-));
+						<TableCell>
+							{offer.data.type === 'Decentralized' ? 'P2P' : 'Centralized'}
+						</TableCell>
+						<TableCell>
+							<Grid container>
+								{offer.data.assets &&
+									offer.data.assets.map(tag => (
+										<Tag key={tag} onClick={() => this.selectToken(tag)}>
+											{tag}
+										</Tag>
+									))}
+							</Grid>
+						</TableCell>
+						<TableCell>{offer.data.interestRate}</TableCell>
+						<TableCell>
+							{offer.loanPayment.totalInterest.toLocaleString('en-US', {
+								style: 'currency',
+								currency
+							})}
+						</TableCell>
+						<TableCell className={classes.detailsCell}>
+							<DetailsButton onClick={() => onDetailsClick(offer)} />
+						</TableCell>
+					</TableRow>
+				))}
+			</TableBody>
+		</Table>
+	)
+);
 
 export default LoansCalculatorLendTable;
 export { LoansCalculatorLendTable };

--- a/src/renderer/marketplace/loans/common/calculator-card.jsx
+++ b/src/renderer/marketplace/loans/common/calculator-card.jsx
@@ -43,13 +43,7 @@ class LoansCalculatorCardComponent extends PureComponent {
 			<Card className={classes.card}>
 				<CardContent className={classes.container}>
 					<ModalCloseIcon className={classes.closeIcon} onClick={onClose} />
-					<Grid
-						container
-						direction="column"
-						justify="center"
-						alignItems="flex-start"
-						spacing={24}
-					>
+					<Grid container direction="column" justify="center" alignItems="flex-start">
 						<div style={{ display: 'flex' }}>
 							<div className={classes.calculatorIcon}>
 								<CalculatorIcon />
@@ -62,7 +56,7 @@ class LoansCalculatorCardComponent extends PureComponent {
 									Know exactly the collateral amount needed to get a loan and the
 									total cost of it. No more unanswered questions.
 								</Typography>
-								<Grid container spacing={16} className={classes.buttons}>
+								<Grid container className={classes.buttons}>
 									<Grid item className={classes.extraSpace}>
 										<Button
 											variant="contained"

--- a/src/renderer/marketplace/loans/common/filters.jsx
+++ b/src/renderer/marketplace/loans/common/filters.jsx
@@ -69,7 +69,7 @@ const LoansFilters = withStyles(styles)(
 			<Grid
 				id="loans-filter"
 				container
-				direction="fow"
+				direction="row"
 				justify="flex-start"
 				spacing={5}
 				className={classes.container}

--- a/src/renderer/marketplace/loans/list/list-container.jsx
+++ b/src/renderer/marketplace/loans/list/list-container.jsx
@@ -10,13 +10,14 @@ import { MarketplaceLoansComponent } from '../common/marketplace-loans-component
 import { identitySelectors } from 'common/identity';
 import { getTokens } from 'common/wallet-tokens/selectors';
 import { walletSelectors, walletOperations } from 'common/wallet';
+import { fiatCurrencyOperations, fiatCurrencySelectors } from 'common/fiatCurrency';
 
 const styles = theme => ({});
 
 class LoansListContainer extends MarketplaceLoansComponent {
 	componentDidMount() {
-		// TODO: load exchange rates
 		window.scrollTo(0, 0);
+		this.props.dispatch(fiatCurrencyOperations.loadExchangeRatesOperation());
 	}
 
 	onBackClick = () => this.props.dispatch(push(this.marketplaceRootPath()));
@@ -27,8 +28,7 @@ class LoansListContainer extends MarketplaceLoansComponent {
 		this.props.dispatch(walletOperations.setLoanCardStatusOperation(true));
 
 	render() {
-		const { isLoading, rates, vendors, inventory, tokens, cardHidden } = this.props;
-
+		const { isLoading, rates, vendors, inventory, tokens, cardHidden, fiatRates } = this.props;
 		return (
 			<LoansListPage
 				vendors={vendors}
@@ -40,6 +40,7 @@ class LoansListContainer extends MarketplaceLoansComponent {
 				loading={isLoading}
 				tokens={tokens}
 				cardHidden={cardHidden}
+				fiatRates={fiatRates}
 			/>
 		);
 	}
@@ -64,7 +65,8 @@ const mapStateToProps = (state, props) => {
 		isLoading: marketplaceSelectors.isInventoryLoading(state),
 		rates: pricesSelectors.getPrices(state).prices,
 		cardHidden: walletSelectors.getLoanCalculatorCardStatus(state),
-		tokens: getTokens(state)
+		tokens: getTokens(state),
+		fiatRates: fiatCurrencySelectors.selectFiatRates(state)
 	};
 };
 

--- a/src/renderer/marketplace/loans/list/list-container.jsx
+++ b/src/renderer/marketplace/loans/list/list-container.jsx
@@ -15,6 +15,7 @@ const styles = theme => ({});
 
 class LoansListContainer extends MarketplaceLoansComponent {
 	componentDidMount() {
+		// TODO: load exchange rates
 		window.scrollTo(0, 0);
 	}
 

--- a/src/renderer/marketplace/loans/list/list-page.jsx
+++ b/src/renderer/marketplace/loans/list/list-page.jsx
@@ -58,7 +58,8 @@ class LoansListPageComponent extends PureComponent {
 			tokens,
 			rates,
 			cardHidden,
-			onCloseCalculatorCardClick
+			onCloseCalculatorCardClick,
+			fiatRates
 		} = this.props;
 		const { tab } = this.state;
 		return (
@@ -117,6 +118,7 @@ class LoansListPageComponent extends PureComponent {
 									tokens={tokens}
 									tab={tab}
 									rates={rates}
+									fiatRates={fiatRates}
 								/>
 							</Grid>
 						</Grid>

--- a/src/renderer/marketplace/marketplace-container.jsx
+++ b/src/renderer/marketplace/marketplace-container.jsx
@@ -51,7 +51,7 @@ class MarketplaceContainerComponent extends PureComponent {
 		return (
 			<Switch>
 				<Route
-					exact="1"
+					exact={true}
 					path={`${match.path}`}
 					component={MarketplaceCategoriesContainer}
 				/>


### PR DESCRIPTION
Addresses #2198 - displaying loan data in different currencies.
Gets fiat currency exchanges rates when needed from api.exchangeratesapi.io free service.
Allows loan calculations to be displayed in USD, EUR and GBP.