### PR TITLE
fix: support unlimited max loan term in calculator filters

### DIFF
--- a/src/renderer/marketplace/exchanges/exchanges-details.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-details.jsx
@@ -153,8 +153,7 @@ const styles = theme => ({
 
 	providerDescription: {
 		marginBottom: '20px',
-		textAlign: 'left',
-		marginRight: '55px'
+		textAlign: 'left'
 	},
 
 	exchange: {

--- a/src/renderer/marketplace/loans/calculator/index.jsx
+++ b/src/renderer/marketplace/loans/calculator/index.jsx
@@ -239,7 +239,10 @@ class LoansCalculatorComponent extends MarketplaceLoansComponent {
 
 		// Filter and remove offers with loan term < user selected period
 		results = results.filter(offer => {
-			return Number(offer.data.maxLoanTerm.replace(/[^0-9.-]+/g, '')) >= period;
+			return (
+				Number(offer.data.maxLoanTerm.replace(/[^0-9.-]+/g, '')) >= period ||
+				offer.data.maxLoanTerm === 'Unlimited'
+			);
 		});
 
 		// Filters by asset

--- a/src/renderer/marketplace/loans/details/details.jsx
+++ b/src/renderer/marketplace/loans/details/details.jsx
@@ -157,8 +157,7 @@ const styles = theme => ({
 
 	providerDescription: {
 		marginBottom: '20px',
-		textAlign: 'left',
-		marginRight: '55px'
+		textAlign: 'left'
 	},
 
 	exchange: {


### PR DESCRIPTION
Addresses issues described on #2111 