### PR TITLE
Feat/release 1.6.0 mergeback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
             - run:
                   name: Build App
                   command: yarn dist --publish=never
-                  no_output_timeout: 40m
+                  no_output_timeout: 80m
             - persist_to_workspace:
                   root: .
                   paths:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm config set msvs_version 2015 --global
   - set PATH=C:\Ruby22\bin;%PATH%
-  - gem install sass compass
+  #- gem install sass compass
   - npm i -g yarn
   - yarn install-all
 build_script:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "selfkey-identity-wallet",
 	"productName": "SelfKey Identity Wallet",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "The Official SelfKey Identity Wallet for Desktop",
 	"browser": [
 		"chrome"


### PR DESCRIPTION
- Commented out `gem install sass compass`, it's not needed and shouldn't be there, can be completely deleted.
- Increase no_output_timeout to 80m from 40 on circle-ci build-mac task

Please ignore the commit message referring to 1.6.1