### PR TITLE
2334 marketplace details button

### DIFF
--- a/src/renderer/marketplace/bank-accounts/list/offers-table.jsx
+++ b/src/renderer/marketplace/bank-accounts/list/offers-table.jsx
@@ -8,8 +8,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import classNames from 'classnames';
 import { LargeTableHeadRow, TagTableCell, Tag, KeyTooltip, InfoTooltip } from 'selfkey-ui';
-import { ProgramPrice, FlagCountryName } from '../../common';
-import DetailsButton from '../common/details-button';
+import { DetailsIconButton, ProgramPrice, FlagCountryName } from '../../common';
 
 const styles = theme => ({
 	table: {
@@ -155,7 +154,10 @@ const BankingOffersRow = withStyles(styles)(({ classes, bank, onDetails, keyRate
 				<ProgramPrice label="$" price={bank.price} rate={keyRate} />
 			</TableCell>
 			<TableCell className={classes.detailsCell}>
-				<DetailsButton onClick={() => onDetails(bank)} id={`details${data.countryCode}`} />
+				<DetailsIconButton
+					onClick={() => onDetails(bank)}
+					id={`details${data.countryCode}`}
+				/>
 			</TableCell>
 		</TableRow>
 	);

--- a/src/renderer/marketplace/bank-accounts/list/offers-table.jsx
+++ b/src/renderer/marketplace/bank-accounts/list/offers-table.jsx
@@ -80,10 +80,15 @@ const styles = theme => ({
 		padding: '0 20px'
 	},
 	detailsCell: {
-		width: '55px',
 		color: '#00C0D9',
 		'& span': {
 			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
 		}
 	},
 	goodForCell: {

--- a/src/renderer/marketplace/common/details-icon-button.jsx
+++ b/src/renderer/marketplace/common/details-icon-button.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+import { withStyles } from '@material-ui/styles';
+import { SelectDropdownIcon } from 'selfkey-ui';
+
+const styles = theme => ({
+	button: {
+		cursor: 'pointer',
+		maxWidth: '80px',
+		textAlign: 'left'
+	},
+	icon: {
+		transform: 'rotate(-90deg)'
+	}
+});
+
+const DetailsIconButton = withStyles(styles)(({ classes, disabled = false, onClick, id = '' }) => {
+	return (
+		<Button className={classes.button} onClick={onClick} disabled={disabled}>
+			<SelectDropdownIcon className={classes.icon} />
+		</Button>
+	);
+});
+
+export { DetailsIconButton };

--- a/src/renderer/marketplace/common/index.js
+++ b/src/renderer/marketplace/common/index.js
@@ -3,4 +3,5 @@ export { FlagCountryName } from './flag-country-name';
 export { PageLoading } from './page-loading';
 export { sanitize } from './sanitize-airtable-html';
 export { MarketplaceKycRequirements } from './marketplace-kyc-requirements';
+export { DetailsIconButton } from './details-icon-button';
 export * from './resume-box';

--- a/src/renderer/marketplace/exchanges/exchanges-list-item.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-list-item.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TableRow, TableCell, Typography, Grid } from '@material-ui/core';
 import { withStyles } from '@material-ui/styles';
 import { Tag } from 'selfkey-ui';
-import DetailsButton from '../bank-accounts/common/details-button';
+import { DetailsIconButton } from '../common';
 
 const styles = theme => ({
 	defaultIcon: {
@@ -74,6 +74,19 @@ const styles = theme => ({
 	excludedResidentCell: {
 		minWidth: '200px'
 	},
+	detailsCell: {
+		color: '#00C0D9',
+		padding: '15px 20px',
+		'& span': {
+			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
+		}
+	},
 	'@media screen and (min-width: 1230px)': {
 		excludedResidentCell: {
 			minWidth: '290px'
@@ -97,10 +110,6 @@ export const ExchangesListItem = withStyles(styles)(
 		status,
 		viewAction
 	}) => {
-		const getButtonText = status => {
-			return status === 'Inactive' ? 'Coming Soon' : 'Details';
-		};
-
 		const getColors = () => ['#46dfba', '#46b7df', '#238db4', '#25a788', '#0e4b61'];
 		let random = Math.floor(Math.random() * 4);
 
@@ -193,14 +202,10 @@ export const ExchangesListItem = withStyles(styles)(
 								)
 						  )}
 				</TableCell>
-				<TableCell
-					style={status === 'Inactive' ? { padding: '0 20px' } : { padding: '0 15px' }}
-				>
-					<DetailsButton
-						text={getButtonText(status)}
+				<TableCell className={classes.detailsCell}>
+					<DetailsIconButton
 						onClick={() => (viewAction ? viewAction(id) : '')}
 						disabled={status === 'Inactive'}
-						color={status === 'Inactive' ? 'secondary' : 'primary'}
 					/>
 				</TableCell>
 			</TableRow>

--- a/src/renderer/marketplace/exchanges/exchanges-list.jsx
+++ b/src/renderer/marketplace/exchanges/exchanges-list.jsx
@@ -76,6 +76,19 @@ const styles = theme => ({
 	},
 	hidden: {
 		display: 'none'
+	},
+	detailsCell: {
+		color: '#00C0D9',
+		padding: '15px 20px',
+		'& span': {
+			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
+		}
 	}
 });
 
@@ -192,7 +205,9 @@ export const ExchangesList = withStyles(styles)(
 														Excluded Residents
 													</Typography>
 												</TableCell>
-												<TableCell>&nbsp;</TableCell>
+												<TableCell className={classes.detailsCell}>
+													&nbsp;
+												</TableCell>
 											</LargeTableHeadRow>
 										</TableHead>
 

--- a/src/renderer/marketplace/incorporation/list/incorporations-list-table.jsx
+++ b/src/renderer/marketplace/incorporation/list/incorporations-list-table.jsx
@@ -61,10 +61,16 @@ const styles = theme => ({
 		padding: '0'
 	},
 	detailsCell: {
-		width: '55px',
 		color: '#00C0D9',
+		padding: '15px 20px',
 		'& span': {
 			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
 		}
 	},
 	goodForCell: {

--- a/src/renderer/marketplace/incorporation/list/incorporations-list-table.jsx
+++ b/src/renderer/marketplace/incorporation/list/incorporations-list-table.jsx
@@ -8,8 +8,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import classNames from 'classnames';
 import { LargeTableHeadRow, TagTableCell, Tag } from 'selfkey-ui';
-import { ProgramPrice, FlagCountryName } from '../../common';
-import DetailsButton from '../../bank-accounts/common/details-button';
+import { ProgramPrice, FlagCountryName, DetailsIconButton } from '../../common';
 
 const styles = theme => ({
 	table: {
@@ -151,7 +150,7 @@ const IncorporationsListTable = withStyles(styles)(
 								<ProgramPrice label="$" price={inc.price} rate={keyRate} />
 							</TableCell>
 							<TableCell className={classes.detailsCell}>
-								<DetailsButton onClick={() => onDetailsClick(inc)} />
+								<DetailsIconButton onClick={() => onDetailsClick(inc)} />
 							</TableCell>
 						</TableRow>
 					))}

--- a/src/renderer/marketplace/loans/calculator/borrow-table.jsx
+++ b/src/renderer/marketplace/loans/calculator/borrow-table.jsx
@@ -7,7 +7,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import { LargeTableHeadRow } from 'selfkey-ui';
-import DetailsButton from '../../bank-accounts/common/details-button';
+import { DetailsIconButton } from '../../common';
 
 const styles = theme => ({
 	nameCell: {
@@ -28,8 +28,17 @@ const styles = theme => ({
 		}
 	},
 	detailsCell: {
-		width: '55px',
-		padding: '15px'
+		color: '#00C0D9',
+		padding: '15px 20px',
+		'& span': {
+			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
+		}
 	},
 	logoCell: {
 		padding: '15px 0 15px 25px',
@@ -124,7 +133,7 @@ const LoansCalculatorBorrowTable = withStyles(styles)(
 							</Typography>
 						</TableCell>
 						<TableCell className={classes.detailsCell}>
-							<DetailsButton onClick={() => onDetailsClick(offer)} />
+							<DetailsIconButton onClick={() => onDetailsClick(offer)} />
 						</TableCell>
 					</TableRow>
 				))}

--- a/src/renderer/marketplace/loans/calculator/lend-table.jsx
+++ b/src/renderer/marketplace/loans/calculator/lend-table.jsx
@@ -7,7 +7,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import { LargeTableHeadRow, Tag } from 'selfkey-ui';
-import DetailsButton from '../../bank-accounts/common/details-button';
+import { DetailsIconButton } from '../../common';
 
 const styles = theme => ({
 	nameCell: {
@@ -36,8 +36,17 @@ const styles = theme => ({
 		}
 	},
 	detailsCell: {
-		width: '55px',
-		padding: '15px'
+		color: '#00C0D9',
+		padding: '15px 20px',
+		'& span': {
+			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
+		}
 	}
 });
 
@@ -109,7 +118,7 @@ const LoansCalculatorLendTable = withStyles(styles)(
 							</Typography>
 						</TableCell>
 						<TableCell className={classes.detailsCell}>
-							<DetailsButton onClick={() => onDetailsClick(offer)} />
+							<DetailsIconButton onClick={() => onDetailsClick(offer)} />
 						</TableCell>
 					</TableRow>
 				))}

--- a/src/renderer/marketplace/loans/common/table.jsx
+++ b/src/renderer/marketplace/loans/common/table.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { MarketplaceLoansComponent } from '../common/marketplace-loans-component';
 import { Tag, LargeTableHeadRow } from 'selfkey-ui';
 import { LoansFilters } from './filters';
-import DetailsButton from '../../bank-accounts/common/details-button';
+import { DetailsIconButton } from '../../common';
 
 const styles = theme => ({
 	nameCell: {
@@ -39,8 +39,17 @@ const styles = theme => ({
 		}
 	},
 	detailsCell: {
-		width: '55px',
-		padding: '15px'
+		color: '#00C0D9',
+		padding: '15px 20px',
+		'& span': {
+			cursor: 'pointer'
+		},
+		'& button': {
+			maxWidth: '15px',
+			minWidth: '15px',
+			padding: 0,
+			width: '15px'
+		}
 	}
 });
 
@@ -220,7 +229,7 @@ class LoansTableComponent extends MarketplaceLoansComponent {
 									<Typography variant="h6">{offer.data.maxLoan}</Typography>
 								</TableCell>
 								<TableCell className={classes.detailsCell}>
-									<DetailsButton onClick={() => onDetailsClick(offer)} />
+									<DetailsIconButton onClick={() => onDetailsClick(offer)} />
 								</TableCell>
 							</TableRow>
 						))}


### PR DESCRIPTION
Changes:

- Changed `Details` (text) button to arrow icon in Marketplace tables (`Bank Accounts`, `Incorporation`, `Loans`, `Exchanges`)

From:
<img width="1080" alt="Screenshot 2020-07-27 at 18 24 57" src="https://user-images.githubusercontent.com/7461010/88566579-8536e480-d036-11ea-800b-94e54ea70c0f.png">


To:
<img width="1078" alt="Screenshot 2020-07-27 at 18 23 58" src="https://user-images.githubusercontent.com/7461010/88566612-8f58e300-d036-11ea-9046-4589d97bd9ad.png">
