### PR TITLE
fix: remove link if empty in airtable

### DIFF
--- a/src/renderer/kyc/application/kyc-agreement-text.js
+++ b/src/renderer/kyc/application/kyc-agreement-text.js
@@ -15,23 +15,31 @@ export const KycAgreementText = withStyles(styles)(
 			I consent to share my information with {vendor}, for the purposes of {purpose} and that
 			they may further share this information with partners and affiliates in accordance with
 			their{' '}
-			<a
-				className={classes.link}
-				onClick={e => {
-					window.openExternal(e, privacyPolicy);
-				}}
-			>
-				privacy policy
-			</a>{' '}
+			{privacyPolicy ? (
+				<a
+					className={classes.link}
+					onClick={e => {
+						window.openExternal(e, privacyPolicy);
+					}}
+				>
+					Privacy Policy
+				</a>
+			) : (
+				<span>Privacy Policy</span>
+			)}{' '}
 			and{' '}
-			<a
-				className={classes.link}
-				onClick={e => {
-					window.openExternal(e, termsOfService);
-				}}
-			>
-				terms and conditions
-			</a>
+			{termsOfService ? (
+				<a
+					className={classes.link}
+					onClick={e => {
+						window.openExternal(e, termsOfService);
+					}}
+				>
+					Terms and Conditions
+				</a>
+			) : (
+				<span>Terms and Conditions</span>
+			)}
 			, and by clicking the box, hereby agree to.
 		</Typography>
 	)


### PR DESCRIPTION
Do not render links if terms or privacy for vendor in airtable are empty

<img width="1041" alt="Screenshot 2020-09-28 at 10 05 48" src="https://user-images.githubusercontent.com/1074/94413220-b33dbf80-0172-11eb-88e6-df3fb25c1cd5.png">
