### PR TITLE
fix: show existing DID if already created

### DIFF
--- a/src/renderer/individual/dashboard/overview-tab.jsx
+++ b/src/renderer/individual/dashboard/overview-tab.jsx
@@ -43,7 +43,7 @@ const SelfkeyIdSubheading = ({ email, did }) => (
 	<React.Fragment>
 		<Typography variant="subtitle1">{email}</Typography>
 		<br />
-		{featureIsEnabled('did') && did && (
+		{did && (
 			<Typography variant="subtitle1" color="secondary">
 				did:selfkey:{did}
 			</Typography>


### PR DESCRIPTION
For users that already created a DID, show it in the selfkey profile.