### PR TITLE
fix: prevent export when keystore is unavailable

### DIFF
--- a/src/common/app/index.js
+++ b/src/common/app/index.js
@@ -759,6 +759,10 @@ const selectAutoUpdateDownloaded = state => {
 
 const selectCanExportWallet = state => {
 	const wallet = walletSelectors.getWallet(state);
+	const keystore = selectKeystoreValue(state);
+	if (!keystore) {
+		return false;
+	}
 	return (
 		featureIsEnabled('walletExport') &&
 		!!(wallet && wallet.profile === 'local' && wallet.keystoreFilePath)


### PR DESCRIPTION
Fixes #2608 